### PR TITLE
Rename lsp exec

### DIFF
--- a/baby-l4.cabal
+++ b/baby-l4.cabal
@@ -74,7 +74,7 @@ executable l4
                      , haskeline  >= 0.7
                      , mtl        >= 2.2 && <2.4
 
-executable bl4-lsp-server
+executable lsp-server-bl4
   hs-source-dirs:      lsp
   main-is:             Main.hs
   default-language:    Haskell2010


### PR DESCRIPTION
as `bl4-lsp-server` is alphabetically earlier than `l4` it breaks existing workflow of `stack run` as it comes ahead of `l4` in `stack run` search process
```
stack run --help
  Build and run an executable. Defaults to the first available executable if
  none is provided as the first argument.
```
So renaming in to `lsp-server-bl4` push it below `l4`