### PR TITLE
Add positions to the parser and lexer errors

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -4,9 +4,9 @@ import Parser (parseProgram)
 import System.Environment
 import qualified ToGF as GF
 
-process :: String -> IO ()
-process input = do
-  let ast = parseProgram input
+process :: FilePath -> String -> IO ()
+process filepath input = do
+  let ast = parseProgram filepath input
   case ast of
     Right ast -> do
       putStrLn (show ast)
@@ -22,4 +22,4 @@ main = do
     []      -> putStrLn "Usage: core-language <input file>"
     [fname] -> do
       contents <- readFile fname
-      process contents
+      process fname contents

--- a/src/Lexer.x
+++ b/src/Lexer.x
@@ -158,8 +158,49 @@ data TokenKind
 
 -- For nice parser error messages.
 unLex :: TokenKind -> String
-unLex = show
--- TODO: Do this properly!
+unLex TokenAssert  = "assert"                         
+unLex TokenClass   = "class"                          
+unLex TokenDecl    = "decl"                           
+unLex TokenDefn    = "defn"                           
+unLex TokenExtends = "extends"                        
+unLex TokenLexicon = "lexicon"                        
+unLex TokenRule    = "rule"                           
+unLex TokenBool    = "Bool"                           
+unLex TokenInt     = "Int"                            
+unLex TokenLet     = "let"                            
+unLex TokenIn      = "in"                             
+unLex TokenNot     = "not"                            
+unLex TokenForall  = "forall"                         
+unLex TokenExists  = "exists"                         
+unLex TokenIf      = "if"                             
+unLex TokenThen    = "then"                           
+unLex TokenElse    = "else"                           
+unLex TokenFor     = "for"                            
+unLex TokenTrue    = "True"                           
+unLex TokenFalse   = "False"                          
+unLex TokenArrow   = "->"                           
+unLex TokenLambda  = "\\"                             
+unLex TokenImpl    = "-->"                          
+unLex TokenOr      = "||"                           
+unLex TokenAnd     = "&&"                           
+unLex TokenEq      = "="                             
+unLex TokenLt      = "<"                             
+unLex TokenGt      = ">"                             
+unLex TokenAdd     = "+"                           
+unLex TokenSub     = "-"                           
+unLex TokenMul     = "*"                           
+unLex TokenDiv     = "/"                            
+unLex TokenMod     = "%"                            
+unLex TokenDot     = "."                             
+unLex TokenComma   = ","                             
+unLex TokenColon   = ":"                             
+unLex TokenLParen  = "("                             
+unLex TokenRParen  = ")"                             
+unLex TokenLBrace  = "{"                             
+unLex TokenRBrace  = "}"                             
+unLex TokenEOF     = "<EOF>"
+unLex (TokenNum i) = show i
+unLex (TokenSym s) = show s
 
 alexEOF :: Alex Token
 alexEOF = do

--- a/src/Lexer.x
+++ b/src/Lexer.x
@@ -1,16 +1,25 @@
 {
 {-# OPTIONS_GHC -XFlexibleContexts #-}
+{-# OPTIONS -w  #-}
 
 module Lexer (
-  Token(..),
-  scanTokens
+  Token(..)
+  -- scanTokens,
+  , AlexPosn(..)
+  , TokenKind(..)
+  , unLex
+  , Alex(..)
+  , runAlex'
+  , alexMonadScan'
+  , alexError'
 ) where
 
+import Prelude hiding (lex)
 import Control.Monad.Except
 
 }
 
-%wrapper "basic"
+%wrapper "monadUserState"
 
 $digit = 0-9
 $alpha = [a-zA-Z]
@@ -28,63 +37,77 @@ tokens :-
   -- Syntax
   -- Structuring elements of an L4 file
   
-  assert                        { \s -> TokenAssert }
-  class                         { \s -> TokenClass }
-  decl                          { \s -> TokenDecl }
-  defn                          { \s -> TokenDefn }
-  extends                       { \s -> TokenExtends }
-  lexicon                       { \s -> TokenLexicon }
-  rule                          { \s -> TokenRule }
+  assert                        { lex' TokenAssert }
+  class                         { lex' TokenClass }
+  decl                          { lex' TokenDecl }
+  defn                          { lex' TokenDefn }
+  extends                       { lex' TokenExtends }
+  lexicon                       { lex' TokenLexicon }
+  rule                          { lex' TokenRule }
 
   -- Types
-  Bool                          { \s -> TokenBool }
-  Int                           { \s -> TokenInt }
+  Bool                          { lex' TokenBool }
+  Int                           { lex' TokenInt }
 
   -- Expressions
-  let                           { \s -> TokenLet }
-  in                            { \s -> TokenIn }
-  not                           { \s -> TokenNot }
-  forall                        { \s -> TokenForall }
-  exists                        { \s -> TokenExists }
-  if                            { \s -> TokenIf }
-  then                          { \s -> TokenThen }
-  else                          { \s -> TokenElse }
-  for                           { \s -> TokenFor }
-  True                          { \s -> TokenTrue }
-  False                         { \s -> TokenFalse }
+  let                           { lex' TokenLet }
+  in                            { lex' TokenIn }
+  not                           { lex' TokenNot }
+  forall                        { lex' TokenForall }
+  exists                        { lex' TokenExists }
+  if                            { lex' TokenIf }
+  then                          { lex' TokenThen }
+  else                          { lex' TokenElse }
+  for                           { lex' TokenFor }
+  True                          { lex' TokenTrue }
+  False                         { lex' TokenFalse }
 
   -- Symbols
-  "->"                          { \s -> TokenArrow }
-  \\                            { \s -> TokenLambda }
-  "-->"                         { \s -> TokenImpl }
-  "||"                          { \s -> TokenOr }
-  "&&"                          { \s -> TokenAnd }
-  \=                            { \s -> TokenEq }
-  \<                            { \s -> TokenLt }
-  \>                           { \s -> TokenGt }
-  [\+]                          { \s -> TokenAdd }
-  [\-]                          { \s -> TokenSub }
-  [\*]                          { \s -> TokenMul }
-  "/"                           { \s -> TokenDiv }
-  "%"                           { \s -> TokenMod }
-  \.                            { \s -> TokenDot }
-  \,                            { \s -> TokenComma }
-  \:                            { \s -> TokenColon }
-  \(                            { \s -> TokenLParen }
-  \)                            { \s -> TokenRParen }
-  \{                            { \s -> TokenLBrace }
-  \}                            { \s -> TokenRBrace }
+  "->"                          { lex' TokenArrow }
+  \\                            { lex' TokenLambda }
+  "-->"                         { lex' TokenImpl }
+  "||"                          { lex' TokenOr }
+  "&&"                          { lex' TokenAnd }
+  \=                            { lex' TokenEq }
+  \<                            { lex' TokenLt }
+  \>                            { lex' TokenGt }
+  [\+]                          { lex' TokenAdd }
+  [\-]                          { lex' TokenSub }
+  [\*]                          { lex' TokenMul }
+  "/"                           { lex' TokenDiv }
+  "%"                           { lex' TokenMod }
+  \.                            { lex' TokenDot }
+  \,                            { lex' TokenComma }
+  \:                            { lex' TokenColon }
+  \(                            { lex' TokenLParen }
+  \)                            { lex' TokenRParen }
+  \{                            { lex' TokenLBrace }
+  \}                            { lex' TokenRBrace }
  
   -- Numbers and identifiers
-  $digit+                       { \s -> TokenNum (read s) }
-  $alpha [$alpha $digit \_ \']* { \s -> TokenSym s }
+  $digit+                       { lex (TokenNum . read) }
+  $alpha [$alpha $digit \_ \']* { lex TokenSym }
 
 
 {
+-- To improve error messages, We keep the path of the file we are
+-- lexing in our own state.
+data AlexUserState = AlexUserState { filePath :: FilePath }
 
-data Token 
-  =
-    TokenAssert
+alexInitUserState :: AlexUserState
+alexInitUserState = AlexUserState "<unknown>"
+
+getFilePath :: Alex FilePath
+getFilePath = liftM filePath alexGetUserState
+
+setFilePath :: FilePath -> Alex ()
+setFilePath = alexSetUserState . AlexUserState
+
+data Token = Token AlexPosn TokenKind
+  deriving (Show)
+
+data TokenKind
+  = TokenAssert
   | TokenClass
   | TokenDecl
   | TokenDefn
@@ -133,16 +156,63 @@ data Token
   | TokenSym String
   deriving (Eq,Show)
 
-scanTokens :: String -> Except String [Token]
-scanTokens str = go ('\n',[],str) where 
-  go inp@(_,_bs,str) =
-    case alexScan inp 0 of
-     AlexEOF -> return []
-     AlexError _ -> throwError "Invalid lexeme."
-     AlexSkip  inp' len     -> go inp'
-     AlexToken inp' len act -> do
-      res <- go inp'
-      let rest = act (take len str)
-      return (rest : res)
+-- For nice parser error messages.
+unLex :: TokenKind -> String
+unLex = show
+-- TODO: Do this properly!
+
+alexEOF :: Alex Token
+alexEOF = do
+  (p,_,_,_) <- alexGetInput
+  return $ Token p TokenEOF
+
+-- Unfortunately, we have to extract the matching bit of string
+-- ourselves...
+lex :: (String -> TokenKind) -> AlexAction Token
+lex f = \(p,_,_,s) i -> return $ Token p (f (take i s))
+
+-- For constructing tokens that do not depend on
+-- the input
+lex' :: TokenKind -> AlexAction Token
+lex' = lex . const
+
+-- We rewrite alexMonadScan' to delegate to alexError' when lexing fails
+-- (the default implementation just returns an error message).
+alexMonadScan' :: Alex Token
+alexMonadScan' = do
+  inp <- alexGetInput
+  sc <- alexGetStartCode
+  case alexScan inp sc of
+    AlexEOF -> alexEOF
+    AlexError (p, _, _, s) ->
+        alexError' p ("lexical error at character '" ++ take 1 s ++ "'")
+    AlexSkip  inp' len -> do
+        alexSetInput inp'
+        alexMonadScan'
+    AlexToken inp' len action -> do
+        alexSetInput inp'
+        action (ignorePendingBytes inp) len
+
+-- Signal an error, including a commonly accepted source code position.
+alexError' :: AlexPosn -> String -> Alex a
+alexError' (AlexPn _ l c) msg = do
+  fp <- getFilePath
+  alexError (fp ++ ":" ++ show l ++ ":" ++ show c ++ ": " ++ msg)
+
+-- A variant of runAlex, keeping track of the path of the file we are lexing.
+runAlex' :: Alex a -> FilePath -> String -> Either String a
+runAlex' a fp input = runAlex input (setFilePath fp >> a)
+
+-- scanTokens :: String -> Except String [Token]
+-- scanTokens str = go ('\n',[],str) where 
+--   go inp@(_,_bs,str) =
+--     case alexScan inp 0 of
+--      AlexEOF -> return []
+--      AlexError _ -> throwError "Invalid lexeme."
+--      AlexSkip  inp' len     -> go inp'
+--      AlexToken inp' len act -> do
+--       res <- go inp'
+--       let rest = act (take len str)
+--       return (rest : res)
 
 }

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -20,58 +20,60 @@ import Control.Monad.Except
 -- Lexer structure 
 %tokentype { Token }
 
+
 -- Parser monad
-%monad { Except String } { (>>=) } { return }
+%monad { Alex }
+%lexer { lexwrap } { Token _ TokenEOF }
 %error { parseError }
 
 -- Token Names
 %token
-    assert  { TokenAssert }
-    class   { TokenClass }
-    decl    { TokenDecl }
-    defn    { TokenDefn }
-    extends { TokenExtends }
-    lexicon { TokenLexicon }
-    rule    { TokenRule }
+    assert  { Token _ TokenAssert }
+    class   { Token _ TokenClass }
+    decl    { Token _ TokenDecl }
+    defn    { Token _ TokenDefn }
+    extends { Token _ TokenExtends }
+    lexicon { Token _ TokenLexicon }
+    rule    { Token _ TokenRule }
 
-    Bool  { TokenBool }
-    Int   { TokenInt }
+    Bool  { Token _ TokenBool }
+    Int   { Token _ TokenInt }
 
-    let    { TokenLet }
-    in     { TokenIn }
-    not    { TokenNot }
-    forall { TokenForall }
-    exists { TokenExists }
-    if     { TokenIf }
-    then   { TokenThen }
-    else   { TokenElse }
-    for    { TokenFor }
-    true   { TokenTrue }
-    false  { TokenFalse }
+    let    { Token _ TokenLet }
+    in     { Token _ TokenIn }
+    not    { Token _ TokenNot }
+    forall { Token _ TokenForall }
+    exists { Token _ TokenExists }
+    if     { Token _ TokenIf }
+    then   { Token _ TokenThen }
+    else   { Token _ TokenElse }
+    for    { Token _ TokenFor }
+    true   { Token _ TokenTrue }
+    false  { Token _ TokenFalse }
     
-    '\\'  { TokenLambda }
-    '->'  { TokenArrow }
-    '-->' { TokenImpl }
-    '||'  { TokenOr }
-    '&&'  { TokenAnd }
-    '='   { TokenEq }
-    '<'   { TokenLt }
-    '>'   { TokenGt }
-    '+'   { TokenAdd }
-    '-'   { TokenSub }
-    '*'   { TokenMul }
-    '/'   { TokenDiv }
-    '%'   { TokenMod }
-    '.'   { TokenDot }
-    ','   { TokenComma }
-    ':'   { TokenColon }
-    '('   { TokenLParen }
-    ')'   { TokenRParen }
-    '{'   { TokenLBrace }
-    '}'   { TokenRBrace }
+    '\\'  { Token _ TokenLambda }
+    '->'  { Token _ TokenArrow }
+    '-->' { Token _ TokenImpl }
+    '||'  { Token _ TokenOr }
+    '&&'  { Token _ TokenAnd }
+    '='   { Token _ TokenEq }
+    '<'   { Token _ TokenLt }
+    '>'   { Token _ TokenGt }
+    '+'   { Token _ TokenAdd }
+    '-'   { Token _ TokenSub }
+    '*'   { Token _ TokenMul }
+    '/'   { Token _ TokenDiv }
+    '%'   { Token _ TokenMod }
+    '.'   { Token _ TokenDot }
+    ','   { Token _ TokenComma }
+    ':'   { Token _ TokenColon }
+    '('   { Token _ TokenLParen }
+    ')'   { Token _ TokenRParen }
+    '{'   { Token _ TokenLBrace }
+    '}'   { Token _ TokenRBrace }
 
-    NUM   { TokenNum $$ }
-    VAR   { TokenSym $$ }
+    NUM   { Token _ (TokenNum $$) }
+    VAR   { Token _ (TokenSym $$) }
 
 -- Operators
 %right '->'
@@ -195,15 +197,24 @@ Annot : '(' NUM ')'                 { GFAnnot $2 }
 
 
 {
+lexwrap :: (Token -> Alex a) -> Alex a
+lexwrap = (alexMonadScan' >>=)
 
-parseError :: [Token] -> Except String a
-parseError (l:ls) = throwError (show l)
-parseError [] = throwError "Unexpected end of Input"
+parseError :: Token -> Alex a
+parseError (Token p t) =
+  alexError' p ("parse error at token '" ++ unLex t ++ "'")
 
-parseProgram:: String -> Either String (Program (Maybe ClassName) ())
-parseProgram input = runExcept $ do
-  tokenStream <- scanTokens input
-  program tokenStream
+-- parseError :: [Token] -> Except String a
+-- parseError (l:ls) = throwError (show l)
+-- parseError [] = throwError "Unexpected end of Input"
+
+parseProgram :: FilePath -> String -> Either String (Program (Maybe ClassName) ())
+parseProgram = runAlex' program
+
+-- parseProgram:: String -> Either String (Program (Maybe ClassName) ())
+-- parseProgram input = runExcept $ do
+--   tokenStream <- scanTokens input
+--   program tokenStream
 
 -- still needed ???
 -- parseTokens :: String -> Either String [Token]


### PR DESCRIPTION
Output from example:
Parser Error:
"l4/cr.l4:6:1: parse error at token 'TokenSym \"fefgvv\"'"

Co-authored-by: Andreas Källberg <anka-213@users.noreply.github.com>