### PR TITLE
Add source locations to the AST and prepare for LSP use

### DIFF
--- a/lsp/Main.hs
+++ b/lsp/Main.hs
@@ -22,6 +22,11 @@ import Data.Traversable ( for )
 import Data.Functor.Const (Const(..))
 import Parser (parseProgram)
 import Data.Foldable (for_)
+import qualified Data.List as List
+import Syntax
+import Control.Lens.Extras (template)
+import Data.Data (Data)
+-- import Syntax (Pos(..),SRng(..))
 
 type Config = ()
 
@@ -81,7 +86,7 @@ parseAndSendErrors uri contents = do
       let
         nuri = toNormalizedUri uri
         diags = [J.Diagnostic
-                  (epos err)
+                  (errorRange err)
                   (Just J.DsError)  -- severity
                   Nothing  -- code
                   (Just "lexer") -- source
@@ -95,11 +100,35 @@ parseAndSendErrors uri contents = do
 tshow :: Show a => a -> T.Text
 tshow = T.pack . show
 
-posInRange :: Position -> Range -> Bool
-posInRange (Position line col) (Range (Position top left) (Position bottom right)) =
+posInRange :: Position -> SRng -> Bool
+posInRange (Position line col) (SRng (Pos top left) (Pos bottom right)) =
   (line == top && col >= left || line > top)
   && (line == bottom && col <= right || line < bottom)
 
+-- | Convert l4 source ranges to lsp source ranges
+posToRange :: SRng -> Range
+posToRange (SRng (Pos l1 c1) (Pos l2 c2)) = Range (Position l1 l2) (Position l2 c2)
+
+-- | Extract the range from an alex/happy error
+errorRange :: Err -> Range
+errorRange = posToRange . epos
+
+-- TODO: Use findAllExpressions and findExprAt to extract types for hover
+
+-- TODO: Show type errors as diagnostics
+
+findAllExpressions :: (Data ct, Data et) => Program ct et -> [Expr et]
+findAllExpressions = toListOf template
+
+-- | Find the smallest subexpression which contains the specified position
+findExprAt :: J.Position -> Expr t -> Expr t
+findExprAt pos expr =
+  case List.find (posInRange pos . getLoc) (childExprs expr) of
+    Nothing -> expr
+    Just sub -> findExprAt pos sub
+
+-- | Temporary bad debugging function.
+-- Use @debugM@ instead
 elog :: (MonadIO m, Show a) => a -> m ()
 elog = liftIO . hPutStrLn stderr . tshow
 
@@ -123,7 +152,7 @@ lookupToken pos (TextDocumentIdentifier uri) = do
     Left err -> do
       let
         diags = [J.Diagnostic
-                  (epos err)
+                  (errorRange err)
                   (Just J.DsError)  -- severity
                   Nothing  -- code
                   (Just "lexer") -- source
@@ -135,8 +164,9 @@ lookupToken pos (TextDocumentIdentifier uri) = do
 
       _ <- sendNotification SWindowShowMessage $ ShowMessageParams MtError $ tshow err
       return Nothing
-      -- TODO: Clear diagnostics when they are no longer relevant
     Right tokens -> do
+      -- TODO: Clear diagnostics when they are no longer relevant
+      -- TODO: The line below does nothing! See #19
       publishDiagnostics 100 nuri Nothing (partitionBySource [])
       let toks = find (posInRange pos . tokenPos) tokens
       -- sendNotification SWindowShowMessage $ ShowMessageParams MtInfo $ tshow pos <> tshow toks
@@ -146,7 +176,7 @@ lookupToken pos (TextDocumentIdentifier uri) = do
         let
           ms = HoverContents $ markedUpContent "haskell" $ tshow tok --tokenKind
         in
-          Hover ms $ Just $ tokenPos tok
+          Hover ms $ Just $ posToRange $ tokenPos tok
 
 syncOptions :: J.TextDocumentSyncOptions
 syncOptions = J.TextDocumentSyncOptions

--- a/src/Lexer.x
+++ b/src/Lexer.x
@@ -30,9 +30,8 @@ import Data.Word (Word8)
 
 import Data.Char (ord)
 import qualified Data.Bits
-import qualified Language.LSP.Types            as J
 
-import Syntax (HasAnn(..))
+import Syntax (HasLoc(..), SRng(..), Pos(..))
 
 
 }
@@ -353,7 +352,7 @@ token t input__ len = return (t input__ len)
 -- End copied AlexWrapper code --
 ---------------------------------
 
-data Err = Err { epos :: J.Range , msg :: String }
+data Err = Err { epos :: SRng , msg :: String }
   deriving (Show)
 
 -- To improve error messages, We keep the path of the file we are
@@ -369,10 +368,8 @@ getFilePath = liftM filePath alexGetUserState
 setFilePath :: FilePath -> Alex ()
 setFilePath = alexSetUserState . AlexUserState
 
-type Token = TokenAnn J.Range
-
-data TokenAnn a = Token { tokenPos:: a, tokenKind :: TokenKind }
-  deriving (Show, Functor)
+data Token = Token { tokenPos :: SRng, tokenKind :: TokenKind }
+  deriving (Show)
 
 getTokenKind (Token _ k) = k
 
@@ -505,8 +502,8 @@ alexMonadScan' = do
         action (ignorePendingBytes inp) len
 
 -- Signal an error, including a commonly accepted source code position.
-alexError' :: J.Range -> String -> Alex a
-alexError' p@(J.Range (J.Position l c) _) msg = do
+alexError' :: SRng -> String -> Alex a
+alexError' p@(SRng (Pos l c) _) msg = do
   fp <- getFilePath
   alexError $ Err p (fp ++ ":" ++ show (l+1) ++ ":" ++ show (c+1) ++ ": " ++ msg)
 
@@ -534,30 +531,30 @@ scanTokens = runAlex' allTokens
 scanFile :: FilePath -> IO (Either Err [Token])
 scanFile fname = scanTokens fname <$> readFile fname
 
-alex2lspRng :: AlexPosn -> Int -> J.Range
-alex2lspRng tokenPos tokenLen = J.Range startPos endPos
+alex2lspRng :: AlexPosn -> Int -> SRng
+alex2lspRng tokenPos tokenLen = SRng startPos endPos
   where
     startPos = aposToPos tokenPos
     endPos = offset tokenLen startPos
 
-aposToPos :: AlexPosn -> J.Position
-aposToPos (AlexPn _ l c) = J.Position (l - 1) (c - 1)
+aposToPos :: AlexPosn -> Pos
+aposToPos (AlexPn _ l c) = Pos (l - 1) (c - 1)
 
 -- horizontal offset, assuming tokens do not extend over several lines
-offset :: Int -> J.Position -> J.Position
-offset n (J.Position l c) = J.Position l (c + n)
+offset :: Int -> Pos -> Pos
+offset n (Pos l c) = Pos l (c + n)
 
-coordFromTo :: J.Range -> J.Range -> J.Range
-coordFromTo (J.Range f1 t1) (J.Range f2 t2) = J.Range f1 t2
+coordFromTo :: SRng -> SRng -> SRng
+coordFromTo (SRng f1 t1) (SRng f2 t2) = SRng f1 t2
 
-tokenRange :: (HasAnn f, HasAnn g) => f J.Range -> g J.Range -> J.Range
-tokenRange a b = coordFromTo (getAnn a) (getAnn b)
+tokenRange :: (HasLoc f, HasLoc g) => f -> g -> SRng
+tokenRange a b = coordFromTo (getLoc a) (getLoc b)
 
-startOf :: J.Range -> J.Position
-startOf (J.Range s _) = s
+startOf :: SRng -> Pos
+startOf (SRng s _) = s
 
-instance HasAnn TokenAnn where
-  getAnn = tokenPos
+instance HasLoc Token where
+  getLoc = tokenPos
 
 -- This might be useful for looking up token locations:
 -- http://hackage.haskell.org/package/IntervalMap

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -74,7 +74,7 @@ import Control.Monad.Except
     '}'   { Token _ TokenRBrace }
 
     NUM   { Token pos (TokenNum $$) }
-    VAR   { Token pos (TokenSym $$) }
+    VAR   { Token _ (TokenSym _) }
 
 -- Operators
 %right '->'
@@ -95,28 +95,28 @@ Program : Lexicon  ClassDecls GlobalVarDecls Rules Assertions
 Lexicon : lexicon Mappings { $2 }
 Mappings :                   {[]}
           | Mappings Mapping {$2 : $1 }
-Mapping : VAR '->' VAR { Mapping $1 $3 }
+Mapping : VAR '->' VAR { Mapping (tokenRange $1 $3) (tokenSym $1) (tokenSym $3) }
 ClassDecls :                       { [] }
            | ClassDecls ClassDecl  { $2 : $1 }
-ClassDecl : class VAR ClassDef     { ClassDecl (ClsNm $2) $3 }
+ClassDecl : class VAR ClassDef     { ClassDecl (ClsNm $ tokenSym $2) $3 }
 
 ClassDef :  '{' FieldDecls '}'     { ClassDef (Just (ClsNm "Object")) (reverse $2) }
          |   extends VAR '{' FieldDecls '}'
-                                   { ClassDef (Just (ClsNm $2)) (reverse $4) }
+                                   { ClassDef (Just (ClsNm $ tokenSym $2)) (reverse $4) }
 FieldDecls :                       { [] }
            | FieldDecls FieldDecl  { $2 : $1 }
 
-FieldDecl : VAR ':' Tp             { FieldDecl (FldNm $1) $3 }
+FieldDecl : VAR ':' Tp             { FieldDecl (FldNm $ tokenSym $1) $3 }
 
 GlobalVarDecls :                         { [] }
          | GlobalVarDecls GlobalVarDecl  { $2 : $1 }
 
-GlobalVarDecl : decl VAR ':' Tp          { VarDecl $2 $4 }
+GlobalVarDecl : decl VAR ':' Tp          { VarDecl (tokenSym $2) $4 }
 
 VarDeclsCommaSep :  VarDecl              { [$1] }
          | VarDeclsCommaSep  ',' VarDecl { $3 : $1 }
 
-VarDecl : VAR ':' Tp                     { VarDecl $1 $3 }
+VarDecl : VAR ':' Tp                     { VarDecl (tokenSym $1) $3 }
 
 
 Assertions :                       { [] }
@@ -126,7 +126,7 @@ Assertion : assert Expr            { Assertion $2 }
 -- Atomic type
 ATp   : Bool                      { BoolT }
      | Int                        { IntT }
-     | VAR                        { ClassT (ClsNm $1) }
+     | VAR                        { ClassT (ClsNm $ tokenSym $1) }
      | '(' TpsCommaSep ')'        { let tcs = $2 in if length tcs == 1 then head tcs else TupleT (reverse tcs) }
 
 TpsCommaSep :                      { [] }
@@ -137,44 +137,44 @@ Tp   : ATp                        { $1 }
      | Tp '->' Tp                 { FunT $1 $3 }
 
 
-Pattern : VAR                      { VarP $1 }
+Pattern : VAR                      { VarP $ tokenSym $1 }
     | '(' VarsCommaSep ')'         { let vcs = $2 in if length vcs == 1 then VarP (head vcs) else VarListP (reverse vcs) }
 
 VarsCommaSep :                      { [] }
-            | VAR                   { [$1] }
-            | VarsCommaSep ',' VAR  { $3 : $1 }
+            | VAR                   { [tokenSym $1] }
+            | VarsCommaSep ',' VAR  { tokenSym $3 : $1 }
 
-Expr : '\\' Pattern ':' ATp '->' Expr  { FunE (tokenRange $1 $6) $2 $4 $6 }
-     | forall VAR ':' Tp '.' Expr      { QuantifE (tokenRange $1 $6) All $2 $4 $6 }
-     | exists VAR ':' Tp '.' Expr      { QuantifE (tokenRange $1 $6) Ex $2 $4 $6 }
-     | Expr '-->' Expr             { BinOpE (tokenRange $1 $3) (BBool BBimpl) $1 $3 }
-     | Expr '||' Expr              { BinOpE (tokenRange $1 $3) (BBool BBor) $1 $3 }
-     | Expr '&&' Expr              { BinOpE (tokenRange $1 $3) (BBool BBand) $1 $3 }
-     | if Expr then Expr else Expr { IfThenElseE (tokenRange $1 $6) $2 $4 $6 }
-     | not Expr                    { UnaOpE (tokenRange $1 $2) (UBool UBneg) $2 }
-     | Expr '<' Expr               { BinOpE (tokenRange $1 $3) (BCompar BClt) $1 $3 }
-     | Expr '>' Expr               { BinOpE (tokenRange $1 $3) (BCompar BCgt) $1 $3 }
-     | Expr '=' Expr               { BinOpE (tokenRange $1 $3) (BCompar BCeq) $1 $3 }
-     | Expr '+' Expr               { BinOpE (tokenRange $1 $3) (BArith BAadd) $1 $3 }
-     | Expr '-' Expr               { BinOpE (tokenRange $1 $3) (BArith BAsub) $1 $3 }
-     | '-' Expr %prec AMINUS       { UnaOpE (tokenRange $1 $2) (UArith UAminus) $2 }
-     | Expr '*' Expr               { BinOpE (tokenRange $1 $3) (BArith BAmul) $1 $3 }
-     | Expr '/' Expr               { BinOpE (tokenRange $1 $3) (BArith BAdiv) $1 $3 }
-     | Expr '%' Expr               { BinOpE (tokenRange $1 $3) (BArith BAmod) $1 $3 }
+Expr : '\\' Pattern ':' ATp '->' Expr  { FunE (tokenRange $1 $6) () $2 $4 $6 }
+     | forall VAR ':' Tp '.' Expr      { QuantifE (tokenRange $1 $6) () All (tokenSym $2) $4 $6 }
+     | exists VAR ':' Tp '.' Expr      { QuantifE (tokenRange $1 $6) () Ex (tokenSym $2) $4 $6 }
+     | Expr '-->' Expr             { BinOpE (tokenRange $1 $3) () (BBool BBimpl) $1 $3 }
+     | Expr '||' Expr              { BinOpE (tokenRange $1 $3) () (BBool BBor) $1 $3 }
+     | Expr '&&' Expr              { BinOpE (tokenRange $1 $3) () (BBool BBand) $1 $3 }
+     | if Expr then Expr else Expr { IfThenElseE (tokenRange $1 $6) () $2 $4 $6 }
+     | not Expr                    { UnaOpE (tokenRange $1 $2) () (UBool UBneg) $2 }
+     | Expr '<' Expr               { BinOpE (tokenRange $1 $3) () (BCompar BClt) $1 $3 }
+     | Expr '>' Expr               { BinOpE (tokenRange $1 $3) () (BCompar BCgt) $1 $3 }
+     | Expr '=' Expr               { BinOpE (tokenRange $1 $3) () (BCompar BCeq) $1 $3 }
+     | Expr '+' Expr               { BinOpE (tokenRange $1 $3) () (BArith BAadd) $1 $3 }
+     | Expr '-' Expr               { BinOpE (tokenRange $1 $3) () (BArith BAsub) $1 $3 }
+     | '-' Expr %prec AMINUS       { UnaOpE (tokenRange $1 $2) () (UArith UAminus) $2 }
+     | Expr '*' Expr               { BinOpE (tokenRange $1 $3) () (BArith BAmul) $1 $3 }
+     | Expr '/' Expr               { BinOpE (tokenRange $1 $3) () (BArith BAdiv) $1 $3 }
+     | Expr '%' Expr               { BinOpE (tokenRange $1 $3) () (BArith BAmod) $1 $3 }
      | App                         { $1 }
 
-App : App Acc                     { AppE (tokenRange $1 $2) $1 $2 }
+App : App Acc                     { AppE (tokenRange $1 $2) () $1 $2 }
     | Acc                          { $1 }
 
 -- field access
-Acc : Acc '.' VAR                  { FldAccE (tokenRange $1 (Wrap pos)) $1 (FldNm $3) }
+Acc : Acc '.' VAR                  { FldAccE (tokenRange $1 $3) () $1 (FldNm $ tokenSym $3) }
     | Atom                         { $1 }
 
-Atom : '(' ExprsCommaSep ')'       { let ecs = $2 in if length ecs == 1 then head ecs else TupleE (tokenRange $1 $3) (reverse ecs) }
-     | NUM                         { ValE (pos) (IntV $1) }
-     | VAR                         { VarE (pos) (GlobalVar $1) }
-     | true                        { ValE (tokenPos $1) (BoolV True) }
-     | false                       { ValE (tokenPos $1) (BoolV False) }
+Atom : '(' ExprsCommaSep ')'       { let ecs = $2 in if length ecs == 1 then head ecs else TupleE (tokenRange $1 $3) () (reverse ecs) }
+     | NUM                         { ValE (pos) () (IntV $1) }
+     | VAR                         { VarE (tokenPos $1) () (GlobalVar $ tokenSym $1) }
+     | true                        { ValE (tokenPos $1) () (BoolV True) }
+     | false                       { ValE (tokenPos $1) () (BoolV False) }
 
 ExprsCommaSep :                      { [] }
             | Expr                   { [$1] }
@@ -185,7 +185,7 @@ Rules  :                       { [] }
        | Rules Rule            { $2 : $1}
 Rule:  RuleName RuleVarDecls RulePrecond RuleConcl { Rule $1 $2 $3 $4 }
 
-RuleName: rule '<' VAR '>'     { $3 }
+RuleName: rule '<' VAR '>'     { tokenSym $3 }
 
 RuleVarDecls :                       { [] }
              | for VarDeclsCommaSep  { reverse $2 }
@@ -194,6 +194,9 @@ RulePrecond : if Expr      { $2 }
 RuleConcl   : then Expr    { $2 }
 
 {
+
+tokenSym (Token _ (TokenSym sym)) = sym
+
 lexwrap :: (Token -> Alex a) -> Alex a
 lexwrap = (alexMonadScan' >>=)
 
@@ -207,11 +210,6 @@ parseError (Token p t) =
 
 parseProgram :: FilePath -> String -> Either Err (Program (Maybe ClassName) _)
 parseProgram = runAlex' program
-
-newtype Wrapper a = Wrap a
-
-instance HasAnn Wrapper where
-  getAnn (Wrap a) = a
 
 -- parseProgram:: String -> Either String (Program (Maybe ClassName) ())
 -- parseProgram input = runExcept $ do

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -1,10 +1,15 @@
 
 {-# LANGUAGE DeriveTraversable #-}
+-- {-# LANGUAGE NoFieldSelectors #-}
+{-# OPTIONS_GHC -Wpartial-fields #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 module Syntax where
 
+
 -- Class for annotated expressions
-class HasAnn f where
-  getAnn :: f a -> a
+import qualified Language.LSP.Types as J
+import qualified Data.List as List
+import Data.Data (Data, Typeable)
 
 
 ----------------------------------------------------------------------
@@ -15,19 +20,40 @@ class HasAnn f where
 ----- Names
 type VarName = String
 type RuleName = String
+-- newtype VarName = VarName String
+--   deriving (Eq, Ord, Show, Read, Data, Typeable)
+-- newtype RuleName = RuleName String
+--   deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 newtype ClassName = ClsNm String
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 newtype FieldName = FldNm String
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 newtype PartyName = PtNm String
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
+class HasLoc a where
+  getLoc :: a -> SRng
+
+
+data Pos = Pos
+  { line :: !Int
+  , col  :: !Int
+  }
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
+data SRng = SRng
+  { start :: Pos
+  , end   :: Pos
+  }
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
+
+instance HasLoc SRng where
+  getLoc = id
 
 ----- Program
 
 data Program ct et = Program [Mapping] [ClassDecl ct] [VarDecl] [Rule et] [Assertion et]
-  deriving (Eq, Ord, Show, Read, Functor, Foldable, Traversable)
+  deriving (Eq, Ord, Show, Read, Functor, Data, Typeable)
 
 removeAnnotations :: Program ct et -> Program ct ()
 removeAnnotations = (()<$)
@@ -40,25 +66,25 @@ data Tp
   | FunT Tp Tp
   | TupleT [Tp]
   | ErrT
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 data VarDecl = VarDecl VarName Tp
-  deriving (Eq, Ord, Show, Read)
-data Mapping = Mapping VarName VarName
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
+data Mapping = Mapping SRng VarName VarName
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- Field attributes: for example cardinality restrictions
 -- data FieldAttribs = FldAtt
 data FieldDecl = FieldDecl FieldName Tp -- FieldAttribs
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- superclass, list of field declarations
 data ClassDef t = ClassDef t [FieldDecl]
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Functor, Data, Typeable)
 
 -- declares class with ClassName and definition as of ClassDef
 data ClassDecl t = ClassDecl ClassName (ClassDef t)
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Functor, Data, Typeable)
 
 name_of_class_decl :: ClassDecl t -> ClassName
 name_of_class_decl (ClassDecl cn _) = cn
@@ -112,92 +138,125 @@ data Val
     -- TODO: instead of RecordV, introduce RecordE in type Expr
     | RecordV ClassName [(FieldName, Val)]
     | ErrV
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 data Var
     = GlobalVar VarName             -- global variable only known by its name
     | LocalVar VarName Int          -- local variable known by its provisional name and deBruijn index.
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- unary arithmetic operators
 data UArithOp = UAminus
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- unary boolean operators
 data UBoolOp = UBneg
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- unary operators (union of the above)
 data UnaOp
     = UArith UArithOp
     | UBool UBoolOp
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- binary arithmetic operators
 data BArithOp = BAadd | BAsub | BAmul | BAdiv | BAmod
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- binary comparison operators
 data BComparOp = BCeq | BClt | BClte | BCgt | BCgte | BCne
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- binary boolean operators
 data BBoolOp = BBimpl | BBor | BBand
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- binary operators (union of the above)
 data BinOp
     = BArith BArithOp
     | BCompar BComparOp
     | BBool BBoolOp
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- operators for combining list elements
 data ListOp = AndList | OrList | XorList | CommaList
-    deriving (Eq, Ord, Show, Read)
+    deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 data Pattern
     = VarP String
     | VarListP [String]
-    deriving (Eq, Ord, Show, Read)
+    deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 data Quantif = All | Ex
-    deriving (Eq, Ord, Show, Read)
+    deriving (Eq, Ord, Show, Read, Data, Typeable)
+
+
+data FooBar
+  = Foo {x :: Int, _y :: Char}
+  | Bar {x :: Int}
 
 
 -- Expr t is an expression of type t (to be determined during type checking / inference)
 data Expr t
-    = ValE t Val                                -- value
-    | VarE t Var                                -- variable
-    | UnaOpE t UnaOp (Expr t)                   -- unary operator
-    | BinOpE t BinOp (Expr t) (Expr t)          -- binary operator
-    | IfThenElseE t (Expr t) (Expr t) (Expr t)  -- conditional
-    | AppE t (Expr t) (Expr t)                  -- function application
-    | FunE t Pattern Tp (Expr t)                -- function abstraction
-    | QuantifE t Quantif VarName Tp (Expr t)    -- quantifier
-    | ClosE t [(VarName, Expr t)] (Expr t)      -- closure  (not externally visible)
-    | FldAccE t (Expr t) FieldName              -- field access
-    | TupleE t [Expr t]                         -- tuples
-    | CastE t Tp (Expr t)                       -- cast to type
-    | ListE t ListOp [Expr t]                   -- list expression
-    deriving (Eq, Ord, Show, Read, Functor, Foldable, Traversable)
-instance HasAnn Expr where
-  getAnn = tpOfExpr
+    = ValE        SRng t Val                          -- value
+    | VarE        SRng t Var                          -- variable
+    | UnaOpE      SRng t UnaOp (Expr t)               -- unary operator
+    | BinOpE      SRng t BinOp (Expr t) (Expr t)      -- binary operator
+    | IfThenElseE SRng t (Expr t) (Expr t) (Expr t)   -- conditional
+    | AppE        SRng t (Expr t) (Expr t)            -- function application
+    | FunE        SRng t Pattern Tp (Expr t)          -- function abstraction
+    | QuantifE    SRng t Quantif VarName Tp (Expr t)  -- quantifier
+    | ClosE       SRng t [(VarName, Expr t)] (Expr t) -- closure  (not externally visible)
+    | FldAccE     SRng t (Expr t) FieldName           -- field access
+    | TupleE      SRng t [Expr t]                     -- tuples
+    | CastE       SRng t Tp (Expr t)                  -- cast to type
+    | ListE       SRng t ListOp [Expr t]              -- list expression
+    deriving (Eq, Ord, Show, Read, Functor, Data, Typeable)
+instance HasLoc (Expr t) where
+  getLoc x = case x of
+    ValE        loc _ _       -> loc
+    VarE        loc _ _       -> loc
+    UnaOpE      loc _ _ _     -> loc
+    BinOpE      loc _ _ _ _   -> loc
+    IfThenElseE loc _ _ _ _   -> loc
+    AppE        loc _ _ _     -> loc
+    FunE        loc _ _ _ _   -> loc
+    QuantifE    loc _ _ _ _ _ -> loc
+    FldAccE     loc _ _ _     -> loc
+    TupleE      loc _ _       -> loc
+    CastE       loc _ _ _     -> loc
+    ListE       loc _ _ _     -> loc
+
+childExprs :: Expr t -> [Expr t]
+childExprs x = case x of
+    ValE        _ _ _       -> []
+    VarE        _ _ _       -> []
+    UnaOpE      _ _ _ a     -> [a]
+    BinOpE      _ _ _ a b   -> [a,b]
+    IfThenElseE _ _ i t e   -> [i,t,e]
+    AppE        _ _ f x     -> [f,x]
+    FunE        _ _ _ _ x   -> [x]
+    QuantifE    _ _ _ _ _ x -> [x]
+    FldAccE     _ _ x _     -> [x]
+    TupleE      _ _ xs      -> xs
+    CastE       _ _ _ x     -> [x]
+    ListE       _ _ _ xs     -> xs
+
 
 tpOfExpr :: Expr t -> t
 tpOfExpr x = case x of
-  ValE t _      -> t
-  VarE t _      -> t
-  UnaOpE t _ _  -> t
-  BinOpE t _ _ _  -> t
-  IfThenElseE t _ _ _ -> t
-  AppE t _ _  -> t
-  FunE t _ _ _  -> t
-  QuantifE t _ _ _ _ -> t
-  FldAccE t _ _ -> t
-  TupleE t _ -> t
-  CastE t _ _     -> t
-  ListE t _ _     -> t
+  ValE        _ t _       -> t
+  VarE        _ t _       -> t
+  UnaOpE      _ t _ _     -> t
+  BinOpE      _ t _ _ _   -> t
+  IfThenElseE _ t _ _ _   -> t
+  AppE        _ t _ _     -> t
+  FunE        _ t _ _ _   -> t
+  QuantifE    _ t _ _ _ _ -> t
+  FldAccE     _ t _ _     -> t
+  TupleE      _ t _       -> t
+  CastE       _ t _ _     -> t
+  ListE       _ t _ _     -> t
 
 
 -- Cmd t is a command of type t
@@ -205,39 +264,39 @@ data Cmd t
     = Skip                                      -- Do nothing
     | VAssign Var (Expr t)                   -- Assignment to variable
     | FAssign (Expr t) FieldName (Expr t)         -- Assignment to field
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 
 data Rule t = Rule RuleName [VarDecl] (Expr t) (Expr t)
-  deriving (Eq, Ord, Show, Read, Functor, Foldable, Traversable)
+  deriving (Eq, Ord, Show, Read, Functor, Data, Typeable)
 
 data Assertion t = Assertion (Expr t)
-  deriving (Eq, Ord, Show, Read, Functor, Foldable, Traversable)
+  deriving (Eq, Ord, Show, Read, Functor, Data, Typeable)
 
 ----------------------------------------------------------------------
 -- Definition of Timed Automata
 ----------------------------------------------------------------------
 
 data Clock = Cl String
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- Clock constraint of the form x < c.
 -- TODO: Reconsider the Integer. Might also be a subclass of the "Time" class
 data ClConstr = ClCn Clock BComparOp Integer
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 data Loc = Lc String
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- Synchronization type: send or receive
 data Sync = Snd | Rec
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- Action in a transition: the string is the ClassName of a subclass of Event
 data Action
   = Internal
   | Act ClassName Sync
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 action_name :: Action -> [ClassName]
 action_name Internal = []
@@ -245,11 +304,11 @@ action_name (Act cn s) = [cn]
 
 -- Transition condition: clock constraints and Boolean expression
 data TransitionCond t = TransCond [ClConstr] (Expr t)
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- Transition action: synchronization action; clock resets; and execution of command (typically assignments)
 data TransitionAction t = TransAction Action [Clock] (Cmd t)
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 transition_action_name :: TransitionAction t -> [ClassName]
 transition_action_name (TransAction act _ _) = action_name act
@@ -257,7 +316,7 @@ transition_action_name (TransAction act _ _) = action_name act
 -- Transition relation from location to location via Action,
 -- provided [ClConstr] are satisfied; and resetting [Clock]
 data Transition t = Trans Loc (TransitionCond t) (TransitionAction t) Loc
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- Timed Automaton having:
 -- a name
@@ -273,12 +332,12 @@ data Transition t = Trans Loc (TransitionCond t) (TransitionAction t) Loc
 -- Note: the set of locations, actions, clocks could in principle be inferred from the remaining info.
 -- Type parameter t: type of expressions: () or Tp, see function Typing/tpExprr
 data TA t = TmdAut String [Loc] [ClassName] [Clock] [Transition t] [Loc] [(Loc, [ClConstr])] [(Loc, Expr t)]
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- Timed Automata System: a set of TAs running in parallel
 -- Type parameter ext: Environment-specific extension
 data TASys t ext = TmdAutSys [TA t] ext
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 name_of_ta :: TA t -> String
 name_of_ta (TmdAut nm ta_locs ta_act_clss ta_clks trans init_locs invs lbls) = nm
@@ -298,11 +357,11 @@ channels_of_ta (TmdAut nm ta_locs ta_act_clss ta_clks trans init_locs invs lbls)
 data Event t
   = EventClConstr ClConstr
   | EventCond (Expr t)
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- only Must and May, assuming that Shant can be compiled away during syntax analysis
 data Modality = Must | May
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- EventRule with components:
 -- rule name
@@ -316,4 +375,4 @@ data Modality = Must | May
 -- rule name (optional) corresponding to LEST clause
 
 data EventRule t = EvRule RuleName [Event t] Modality [PartyName] Action [ClConstr] RuleName (Maybe RuleName)
-  deriving (Eq, Ord, Show, Read)
+  deriving (Eq, Ord, Show, Read, Data, Typeable)

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -1,7 +1,6 @@
 
-{-# LANGUAGE DeriveTraversable #-}
--- {-# LANGUAGE NoFieldSelectors #-}
-{-# OPTIONS_GHC -Wpartial-fields #-}
+{-# LANGUAGE DeriveFunctor #-}
+-- {-# OPTIONS_GHC -Wpartial-fields #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 module Syntax where
 
@@ -189,11 +188,6 @@ data Pattern
 
 data Quantif = All | Ex
     deriving (Eq, Ord, Show, Read, Data, Typeable)
-
-
-data FooBar
-  = Foo {x :: Int, _y :: Char}
-  | Bar {x :: Int}
 
 
 -- Expr t is an expression of type t (to be determined during type checking / inference)

--- a/src/ToGF.hs
+++ b/src/ToGF.hs
@@ -52,7 +52,7 @@ var2ind :: [Mapping] -> VarName -> GInd
 var2ind lexicon name = case findMapping lexicon name of
     val:_ -> if gfType val == "Noun"
               then GIVarN (LexNoun name)
-              else GIVar (GVString (GString name)) 
+              else GIVar (GVString (GString name))
     _           -> GIVar (GVString (GString name)) -- Fall back to string literal
 
 typ2kind :: [Mapping] -> Tp -> GKind
@@ -67,7 +67,7 @@ typ2kind lexicon e = case e of
 
 expr2prop :: Syntax.Expr Tp -> GProp
 expr2prop e = case e of
-  ValE _ val -> GPAtom (val2atom val)
+  ValE _ _ val -> GPAtom (val2atom val)
   _ -> error $ "expr2prop: not yet supported: " ++ show e
 
 val2atom :: Val -> GAtom
@@ -81,7 +81,7 @@ val2atom e  = case e of
 findMapping :: [Mapping] -> String -> [String]
 findMapping haystack needle =
   [ val
-  | Mapping name val <- haystack
+  | Mapping _ name val <- haystack
   , name == needle ]
 
 type Lang = String
@@ -93,14 +93,14 @@ createLexicon langs lexicon = (abstract,concretes)
       ["abstract PropLexicon = Prop ** {"] ++
       ["fun"] ++
       [ printf "%s : %s ;" name (gfType val)
-      | Mapping name val <- lexicon ] ++
+      | Mapping _ name val <- lexicon ] ++
       ["}"]
     concretes =
       [ unlines $
           [printf "concrete PropLexicon%s of PropLexicon = Prop%s ** open WordNet%s in {" lang lang lang] ++
           ["lin"] ++
           [printf "%s = %s ;" name val
-          | Mapping name val <- lexicon ] ++
+          | Mapping _ name val <- lexicon ] ++
           ["}"]
       | lang <- langs ]
 

--- a/src/Typing.hs
+++ b/src/Typing.hs
@@ -240,26 +240,26 @@ compatiblePatternType _ _ = False
 -- TODO: FldAccE, ListE
 tpExpr :: Environment t -> Expr () -> Expr Tp
 tpExpr env x = case x of
-  ValE () c -> ValE (tpConstval env c) c
-  VarE () v -> VarE (tpVar env v) (varIdentityInEnv env v)
-  UnaOpE () uop e ->
+  ValE loc () c -> ValE loc (tpConstval env c) c
+  VarE loc () v -> VarE loc (tpVar env v) (varIdentityInEnv env v)
+  UnaOpE loc () uop e ->
     let te = tpExpr env e
         t  = tpUnaop (tpOfExpr te) uop
-    in  UnaOpE t uop te
-  BinOpE () bop e1 e2 ->
+    in  UnaOpE loc t uop te
+  BinOpE loc () bop e1 e2 ->
     let te1 = tpExpr env e1
         te2 = tpExpr env e2
         t   = tpBinop (tpOfExpr te1) (tpOfExpr te2) bop
-    in  BinOpE t bop te1 te2
-  IfThenElseE () c e1 e2 ->
+    in  BinOpE loc t bop te1 te2
+  IfThenElseE loc () c e1 e2 ->
     let tc = tpExpr env c
         te1 = tpExpr env e1
         te2 = tpExpr env e2
     in
       if tpOfExpr tc == BoolT && (tpOfExpr te1) == (tpOfExpr te2)
-      then IfThenElseE (tpOfExpr te1) tc te1 te2
-      else  IfThenElseE ErrT tc te1 te2
-  AppE () fe ae ->
+      then IfThenElseE loc (tpOfExpr te1) tc te1 te2
+      else  IfThenElseE loc ErrT tc te1 te2
+  AppE loc () fe ae ->
     let tfe = tpExpr env fe
         tae = tpExpr env ae
         tf  = tpOfExpr tfe
@@ -267,30 +267,30 @@ tpExpr env x = case x of
     in case tf of
       FunT tpar tbody ->
         if tpar == ta
-        then AppE tbody tfe tae
-        else AppE ErrT tfe tae
-      _ -> AppE ErrT tfe tae
-  FunE () pt tparam e ->
+        then AppE loc tbody tfe tae
+        else AppE loc ErrT tfe tae
+      _ -> AppE loc ErrT tfe tae
+  FunE loc () pt tparam e ->
     let te = tpExpr (pushPatternEnv pt tparam env) e
         t  = tpOfExpr te
     in
       -- TODO: the test should come before the recursive call
       -- because pushPatternEnv may lead to a Haskell match failure.
       if compatiblePatternType pt tparam
-      then FunE (FunT tparam t) pt tparam te
-      else FunE ErrT pt tparam te
+      then FunE loc (FunT tparam t) pt tparam te
+      else FunE loc ErrT pt tparam te
   -- ClosE: no explicit typing because not externally visible
-  QuantifE () q vn vt e ->
+  QuantifE loc () q vn vt e ->
     let te = tpExpr (pushLocalVarEnv [(vn, vt)] env) e
     in
       if tpOfExpr te == BoolT
-      then QuantifE BoolT q vn vt te
-      else QuantifE ErrT q vn vt te
-  CastE () ctp e ->
+      then QuantifE loc BoolT q vn vt te
+      else QuantifE loc ErrT q vn vt te
+  CastE loc () ctp e ->
     let te = tpExpr env e
     in if castCompatible (tpOfExpr te) ctp
-       then CastE ctp ctp te
-       else CastE ErrT ctp te
+       then CastE loc ctp ctp te
+       else CastE loc ErrT ctp te
 
 
 


### PR DESCRIPTION
- We used [lenses](https://hackage.haskell.org/package/lens-5.0.1/docs/Data-Data-Lens.html#v:template) to magically traverse the AST to find all expressions.

- There are still plenty of parts of the AST that doesn't have source location information.

Todo:
- [ ] Check if Data.Data.Data slows down compilation times significantly

- [ ] Document things a bit more

Resolves #26

Co-authored-by: Jacob Tan <2jacobtan@users.noreply.github.com>