### PR TITLE
add-r34.l4

### DIFF
--- a/l4/r34.l4
+++ b/l4/r34.l4
@@ -37,8 +37,7 @@
 # 18. The lower a level of detail you choose to model, the easier it is to write the rules, and the harder it is to write
 #     the lexicon.
 # 19. It would be useful if we could also replace the default translation that GF provides on a case-by-case basis, using
-#     something like s(CASP)'s predicate statements, if generating a WordNet phrase is going to be complicated.
-
+#     something like s(CASP)'s predicate statements, as a stop-gap measure.
 
 # TODO: Fill out lexicon
 lexicon

--- a/l4/r34.l4
+++ b/l4/r34.l4
@@ -1,0 +1,300 @@
+# l4 encoding of Rule 34
+
+# TODO Figure out how to approach the LPDAT defeasibility in this syntax.
+
+# Thoughts on Syntax:
+# 1. The way predicates are used in the rules is visually unrelated to both of the
+#    methods of declaring them. That creates cognitive load.
+# 2. Conjunction happens all the time, it should be implicit with newlines.
+# 3. "OR" is clearer than "||", and the same length.
+# 4. We should use indentation instead of brackets.
+# 5. There should be a way to say in the class definition that
+#    certain predicates are true, or have known values, for certain classes.
+#    For example, if LegalPractitioner extends Person, then we should
+#    be able to say that by default, for LegalPractitioner, AuthorizedToPracticeLaw
+#    is true.
+# 6. Using a period to separate the variables and the contents of the quantifiers
+#    is really unintuitive. Again, indentation would be better.
+# 7. Declarating the variables for conditions and quantifications is redundant if the
+#    predicates have been defined with types. You know from DescribedInSection1 b,
+#    that b is a business, because the type of DescribedInSection1 is Business -> Boolean.
+#    Something else could be done to distinguish variables from atoms, I think.
+# 8. I think existential quantification should be implicit if the user doesn't specify.
+# 9. It not clear whether adding -> Boolean to the end of a class attribute declaration does anything.
+# 10. It's not clear whether nesting exists statements is mandatory or optional, or what it means semantically.
+# 11. It's not clear how to test for class membership. is it a unary predicate, or a `:`
+# 12. Are you required to use a type declaration when defining variables for an exists or forall statement? Why?
+#     I'm worried that might force people to fiddle with their object hierarchies, or that it might require
+#     making it possible to extend from multiple classes, or adopt interfaces, or whatever.
+
+
+
+# TODO: Fill out lexicon
+lexicon
+Business -> "business_1_N"
+AssociatedWith -> "mkA2 associated_A with_Prep"
+ExecutiveAppointment -> "appointment_1_N"
+LegalPractitioner -> "lawyer_N"
+
+# Class definitions
+class Business {
+    DescribedInSection1: Boolean
+    DetractsFromDignityOfLegalProfession: Boolean
+    IncompatibleWithDignityOfLegalProfession: Boolean
+    DerogatesFromDignityOfLegalProfession: Boolean
+    Unfair: Boolean
+    DescribedInFirstSchedule: Boolean
+    Prohibited: Boolean
+    InvolvesSharingFeesForLegalWorkByUnauthoirzedPersonsPerformedByTheLegalPractitioner: Boolean
+    InvolvesPaymentOfCommissionsForLegalWorkByUnauthorizedPersonsPerformedByTheLegalPractioner: Boolean
+}
+
+class ExecutiveAppointment extends Position {
+    AssociatedWith: Business
+    MateriallyInterferesWithAvailability: LegalPractitioner
+    MateriallyInterferesWithPracticingAsLawyer: LegalPractitioner
+    MateriallyInterferesWithRepresentation: LegalPractitioner
+}
+
+class Organization {
+    Position: Position
+}
+
+class Position {
+    HeldAsRepresentativeOf: Organization
+}
+
+class LegalPractitioner extends Person {
+    MustNotAccept: Appointment
+    PrimaryOccupationIsPracticingAsLawyer: Boolean
+}
+
+class Person {
+    AuthorizedToPracticeLaw: Boolean
+    Awesome: Boolean
+    Cool: Boolean
+}
+
+class LawPractice extends Organization {
+    Owner: Person
+    LegalOwner: Person
+    BeneficialOwner: Person
+    Partner: Person
+    SoleProprietor: Person
+    Director: Person
+    JurisdictionIsSingapore: Boolean
+    Member: LegalPractitioner
+}
+
+class BusinessEntity extends Organization 
+
+# Rules
+
+# RULE 34
+# 34. Executive appointments
+
+# RULE 34(1)
+# 34.—(1)  A legal practitioner must not accept any executive appointment associated with 
+# any of the following businesses:
+
+rule <r34_1>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    exists b : Business.
+        AssociatedWith ea b &&
+        DescribedInSection1 b
+)
+then MustNotAccept lp ea
+
+# (a)	any business which detracts from, is incompatible with, or derogates from the dignity of,
+# the legal profession;
+
+rule <r34_1_a>
+for b: Business
+if (
+    DetractsFromDignityOfLegalProfession b ||
+    IncompatibleWithDignityOfLegalProfession b ||
+    DerogatesFromDignityOfLegalProfession b
+)
+then DescribedInSection1 b
+
+# section 34(1)(b) is repealed in this version
+
+# (c)	any business which is likely to unfairly attract business in the practice of law;
+
+rule <r34_1_c>
+for b: Business
+if (
+    Unfair b
+)
+then DescribedInSection1 b
+
+# (d)	any business which involves the sharing of the legal practitioner’s fees with, 
+# or the payment of a commission to, any unauthorised person for legal work performed 
+# by the legal practitioner;
+
+rule <r34_1_d>
+for b: Business
+if (
+    # TODO Increase the fidelity of this provision, and see if it needs to be moved
+    # out of r34_1 because it refers to "the legal practitioner"
+    InvolvesSharingFeesForLegalWorkByUnauthoirzedPersonsPerformedByTheLegalPractitioner b ||
+    InvolvesPaymentOfCommissionsForLegalWorkByUnauthorizedPersonsPerformedByTheLegalPractioner b
+)
+then DescribedInSection1 b
+
+# (e)	any business set out in the First Schedule;
+
+rule <r34_1_e>
+for b: Business
+if (
+    DescribedInFirstSchedule b
+)
+then DescribedInSection1 b
+
+# (f)	any business which is prohibited by —
+# (i)	the Act;
+# (ii)	these Rules or any other subsidiary legislation made under the Act;
+# (iii)	any practice directions, guidance notes and rulings issued under section 71(6) of the Act; or
+# (iv)	any practice directions, guidance notes and rulings (relating to professional practice,
+# etiquette, conduct and discipline) issued by the Council or the Society.
+
+rule <r34_1_e>
+for b: Business
+if (
+    Prohibited b
+)
+then DescribedInSection1 b
+
+rule <r34_1A>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    (
+        MateriallyInterferesWithPracticingAsLawyer ea lp &&
+        PrimaryOccupationIsPracticingAsLawyer lp 
+    ) ||
+    MateriallyInterferesWithAvaliability ea lp ||
+    MateriallyInterferesWithRepresentation ea lp
+)
+then MustNotAccept lp ea
+
+# RULE 34(2)(a)
+# (2)  Subject to paragraph (1), a legal practitioner in a Singapore law practice 
+# (called in this paragraph the main practice) may accept an executive appointment 
+# in another Singapore law practice (called in this paragraph the related practice), 
+# if the related practice is connected to the main practice in either of the following ways:
+# (a)	every legal or beneficial owner of the related practice is the sole proprietor, 
+# or a partner or director, of the main practice;
+
+rule <r34_2_a>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    exists own_practice: LawPractice . (
+        Member own_practice lp &&
+        JurisdictionIsSingapore own_practice &&
+        exists other_practice: LawPractice . (
+            not Member other_practice lp &&
+            Position other_practice ea &&
+            JurisdictionIsSingapore other_practice &&
+            not exists o: Person . (
+                (
+                    LegalOwner other_practice o ||
+                    BeneficialOwner other_practice o
+                ) &&
+                not (
+                    SoleProprietor own_practice o ||
+                    Partner own_practice o ||
+                    Director own_practice o
+                )
+            )
+        )
+    )
+)
+then MayAccept lp ea
+
+# RULE 34(2)(b)
+# (b)	the legal practitioner accepts the executive appointment as a representative 
+# of the main practice in the related practice, and the involvement of the main practice 
+# in the related practice is not prohibited by any of the following:
+# (i)	the Act;
+# (ii)	these Rules or any other subsidiary legislation made under the Act;
+# (iii)	any practice directions, guidance notes and rulings issued under section 71(6) of the Act;
+# (iv)	any practice directions, guidance notes and rulings (relating to professional practice,
+# etiquette, conduct and discipline) issued by the Council or the Society.
+
+rule <r34_2_b>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    exists own_practice: LawPractice . (
+        exists other_practice: LawPractice . (
+            Member own_practice lp &&
+            JurisdictionIsSingapore own_practice &&
+            not Member other_practice lp &&
+            Position other_practice ea &&
+            JurisdictionIsSingapore other_practice &&
+            not ParticipationProhibited own_practice other_practice &&
+            HeldAsRepresentativeOf ea own_practice
+        )
+    )
+)
+then MayAccept lp ea
+
+# Example of alternative syntax for above rule.
+# RULE <r34_2_b>
+# IF
+#     LawPractice own_practice
+#         LawPractice other_practice
+#             LegalPractitioner lp
+#             ExecutiveAppointment ea
+#             JurisdictionIsSingapore own_practice
+#             JurisdictionIsSingapore other_practice
+#             not Member other_practice lp
+#             Position ea lp
+#             not ParticipationProhibited own_practice other_practice
+#             HeldAsRepresentativeOf ea own_practice
+# THEN
+#     MayAccept lp ea
+
+# RULE 34(3)
+# (3)  Subject to paragraph (1), a legal practitioner may accept an executive appointment 
+# in a business entity which provides law-related services.
+
+# RULE 34(4)
+# (4)  Subject to paragraph (1), a legal practitioner (not being a locum solicitor) may 
+# accept an executive appointment in a business entity which does not provide any 
+# legal services or law-related services, if all of the conditions set out in the 
+# Second Schedule are satisfied.
+
+# RULE 34(5)
+# (5)  Despite paragraph (1)(b), but subject to paragraph (1)(a) and (c) to (f), 
+# a locum solicitor may accept an executive appointment in a business entity which 
+# does not provide any legal services or law-related services, if all of the 
+# conditions set out in the Second Schedule are satisfied.
+
+# RULE 34(6)
+# (6)  Except as provided in paragraphs (2) to (5) —
+# (a)	a legal practitioner in a Singapore law practice must not accept any executive 
+# appointment in another Singapore law practice; and
+
+# (b)	a legal practitioner must not accept any executive appointment in a business entity.
+
+# RULE 34(7)
+# (7)  To avoid doubt, nothing in this rule prohibits a legal practitioner 
+# from accepting any appointment in any institution set out in the Third Schedule.
+
+# DEFINITIONS
+# (9)  In this rule and the First to Fourth Schedules —
+# “business” includes any business, trade or calling in Singapore or elsewhere, 
+# whether or not for the purpose of profit, but excludes the practice of law;
+
+# “business entity”  —
+# (a)	includes any company, corporation, partnership, limited liability partnership, 
+# sole proprietorship, business trust or other entity that carries on any business; but
+# (b)	excludes any Singapore law practice, any Joint Law Venture, any Formal Law Alliance, 
+# any foreign law practice and any institution set out in the Third Schedule;
+
+# “executive appointment” means a position associated with a business, or in a business 
+# entity or Singapore law practice, which entitles the holder of the position to perform 
+# executive functions in relation to the business, business entity or Singapore law practice 
+# (as the case may be), but excludes any non‑executive director or independent director 
+# associated with the business or in the business entity;

--- a/l4/r34.l4
+++ b/l4/r34.l4
@@ -38,6 +38,9 @@
 #     the lexicon.
 # 19. It would be useful if we could also replace the default translation that GF provides on a case-by-case basis, using
 #     something like s(CASP)'s predicate statements, as a stop-gap measure.
+# 20. The method of defeasibility I'm using below is painful, and inadequate.
+#     Half the code implements defeasibility, when it could be done in a matter of
+#     a dozen lines, or so.
 
 # TODO: Fill out lexicon
 lexicon
@@ -67,9 +70,9 @@ Institution -> "institution_1_N"
 Service -> "service_1_N"
 Legal -> "legal_4_A"
 # HeldAsRepresentativeOf
-# EntitlesHolder
+# EntitlesHolder -> 
 # NonExecutiveDirector
-# IndependentDirector
+# IndependentDirector -> "AdjCN independent_1_A director_2_N"
 # MustNotAccept
 # MayAccept
 # PrimaryOccupationIsPracticingAsLawyer
@@ -78,12 +81,12 @@ Person -> "person_1_N"
 # AuthorizedToPracticeLaw
 # LawPractice -> "legal_4_A practice_3_V2"
 Owner -> "owner_1_N"
-# LegalOwner
-# BeneficialOwner
+# LegalOwner -> "AdjCN legal_4_A owner_1_N"
+# BeneficialOwner -> "mkN beneficial owner_1_N"
 Partner -> "partner_3_N"
 SoleProprietor -> "proprietor_N"
 Director -> "director_2_N"
-# JurisdictionIsSingapore
+# JurisdictionIsSingapore -> "mkN2 in_Prep singapore_2_PN"
 Member -> "member_1_N"
 # BusinessEntity 
 # ThePracticeOfLaw
@@ -93,7 +96,7 @@ Corporation -> "corporation_1_N"
 Partnership -> "partnership_3_N"
 # LLP -> 
 SoleProp -> "proprietorship_N"
-# BusinessTrust -> 
+BusinessTrust -> "CompoundN business_1_N trust_1_N"
 # JointLawVenture
 # FormalLawAlliance
 # ForeignLawPractice
@@ -192,8 +195,164 @@ class FormalLawAlliance
 
 class ForeignLawPractice
 
-
 decl ConditionsOfSecondScheduleAreSatisfied: Global
+
+decl r34_1_applies: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_1_a_applies: Business -> Boolean
+decl r34_1_c_applies: Business -> Boolean
+decl r34_1_d_applies: Business -> Boolean
+decl r34_1_e_applies: Business -> Boolean
+decl r34_1_f_applies: Business -> Boolean
+decl r34_1A_applies: LegalPractitioner -> ExecutiveAppointment  -> Boolean
+decl r34_2_a_applies: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_2_b_applies: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_3_applies: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_4_applies: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_5_applies: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_6_a_applies: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_6_b_applies: LegalPractitioner -> ExecutiveAppointment -> Boolean
+
+decl r34_1_defeated: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_1_a_defeated: Business -> Boolean
+decl r34_1_c_defeated: Business -> Boolean
+decl r34_1_d_defeated: Business -> Boolean
+decl r34_1_e_defeated: Business -> Boolean
+decl r34_1_f_defeated: Business -> Boolean
+decl r34_1A_defeated: LegalPractitioner -> ExecutiveAppointment  -> Boolean
+decl r34_2_a_defeated: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_2_b_defeated: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_3_defeated: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_4_defeated: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_5_defeated: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_6_a_defeated: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_6_b_defeated: LegalPractitioner -> ExecutiveAppointment -> Boolean
+
+decl r34_1_holds: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_1_a_holds: Business -> Boolean
+decl r34_1_c_holds: Business -> Boolean
+decl r34_1_d_holds: Business -> Boolean
+decl r34_1_e_holds: Business -> Boolean
+decl r34_1_f_holds: Business -> Boolean
+decl r34_1A_holds: LegalPractitioner -> ExecutiveAppointment  -> Boolean
+decl r34_2_a_holds: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_2_b_holds: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_3_holds: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_4_holds: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_5_holds: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_6_a_holds: LegalPractitioner -> ExecutiveAppointment -> Boolean
+decl r34_6_b_holds: LegalPractitioner -> ExecutiveAppointment -> Boolean
+
+rule <r34_1_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_1_applies lp ea &&
+    not r34_1_defeated lp ea
+)
+then r34_1_holds lp ea
+
+rule <r34_1_a_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_1_a_applies lp ea &&
+    not r34_1_a_defeated lp ea
+)
+then r34_1_a_holds lp ea
+
+rule <r34_1_c_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_1_c_applies lp ea &&
+    not r34_1_c_defeated lp ea
+)
+then r34_1_c_holds lp ea
+
+rule <r34_1_d_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_1_d_applies lp ea &&
+    not r34_1_d_defeated lp ea
+)
+then r34_1_d_holds lp ea
+
+rule <r34_1_e_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_1_e_applies lp ea &&
+    not r34_1_e_defeated lp ea
+)
+then r34_1_e_holds lp ea
+
+rule <r34_1_f_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_1_f_applies lp ea &&
+    not r34_1_f_defeated lp ea
+)
+then r34_1_f_holds lp ea
+
+rule <r34_1A_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_1A_applies lp ea &&
+    not r34_1A_defeated lp ea
+)
+then r34_1A_holds lp ea
+
+rule <r34_2_a_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_2_a_applies lp ea &&
+    not r34_2_a_defeated lp ea
+)
+then r34_2_a_holds lp ea
+
+rule <r34_2_b_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_2_b_applies lp ea &&
+    not r34_2_b_defeated lp ea
+)
+then r34_2_b_holds lp ea
+
+rule <r34_3_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_3_applies lp ea &&
+    not r34_3_defeated lp ea
+)
+then r34_3_holds lp ea
+
+rule <r34_4_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_4_applies lp ea &&
+    not r34_4_defeated lp ea
+)
+then r34_4_holds lp ea
+
+rule <r34_5_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_5_applies lp ea &&
+    not r34_5_defeated lp ea
+)
+then r34_5holds lp ea
+
+rule <r34_6_a_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_6_a_applies lp ea &&
+    not r34_6_a_defeated lp ea
+)
+then r34_6_a_holds lp ea
+
+rule <r34_6_b_holds>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    r34_6_b_applies lp ea &&
+    not r34_6_b_defeated lp ea
+)
+then r34_6_b_holds lp ea
 
 # Rules
 
@@ -211,7 +370,11 @@ if (
         AssociatedWith ea b &&
         DescribedInSection1 b
 )
-then MustNotAccept lp ea
+then MustNotAccept lp ea && r34_1_applies lp ea && r34_5_defeated lp ea &&
+     r34_2_a_defeated lp ea &&
+     r34_2_b_defeated lp ea &&
+     r34_3_defeated lp ea &&
+     r34_4_defeated lp ea
 
 # (a)	any business which detracts from, is incompatible with, or derogates from the dignity of,
 # the legal profession;
@@ -223,7 +386,7 @@ if (
     IncompatibleWithDignityOfLegalProfession b ||
     DerogatesFromDignityOfLegalProfession b
 )
-then DescribedInSection1 b
+then DescribedInSection1 b && r34_1_a_applies b
 
 # section 34(1)(b) is repealed in this version
 
@@ -234,7 +397,7 @@ for b: Business
 if (
     Unfair b
 )
-then DescribedInSection1 b
+then DescribedInSection1 b && r34_1_c_applies b
 
 # (d)	any business which involves the sharing of the legal practitioner’s fees with, 
 # or the payment of a commission to, any unauthorised person for legal work performed 
@@ -248,7 +411,7 @@ if (
     InvolvesSharingFeesForLegalWorkByUnauthoirzedPersonsPerformedByTheLegalPractitioner b ||
     InvolvesPaymentOfCommissionsForLegalWorkByUnauthorizedPersonsPerformedByTheLegalPractioner b
 )
-then DescribedInSection1 b
+then DescribedInSection1 b && r34_1_d_applies b
 
 # (e)	any business set out in the First Schedule;
 
@@ -257,7 +420,7 @@ for b: Business
 if (
     DescribedInFirstSchedule b
 )
-then DescribedInSection1 b
+then DescribedInSection1 b && r34_1_e_applies b
 
 # (f)	any business which is prohibited by —
 # (i)	the Act;
@@ -266,12 +429,12 @@ then DescribedInSection1 b
 # (iv)	any practice directions, guidance notes and rulings (relating to professional practice,
 # etiquette, conduct and discipline) issued by the Council or the Society.
 
-rule <r34_1_e>
+rule <r34_1_f>
 for b: Business
 if (
     Prohibited b
 )
-then DescribedInSection1 b
+then DescribedInSection1 b && r34_1_f_applies b
 
 rule <r34_1A>
 for lp: LegalPractitioner, ea: ExecutiveAppointment
@@ -283,7 +446,7 @@ if (
     MateriallyInterferesWithAvaliability ea lp ||
     MateriallyInterferesWithRepresentation ea lp
 )
-then MustNotAccept lp ea
+then MustNotAccept lp ea && r34_1A_applies lp ea
 
 # RULE 34(2)(a)
 # (2)  Subject to paragraph (1), a legal practitioner in a Singapore law practice 
@@ -317,7 +480,9 @@ if (
         )
     )
 )
-then MayAccept lp ea
+then MayAccept lp ea && r34_2_a_applies lp ea &&
+     r34_6_a_defeated lp ea &&
+     r34_6_b_defeated lp ea
 
 # RULE 34(2)(b)
 # (b)	the legal practitioner accepts the executive appointment as a representative 
@@ -344,7 +509,9 @@ if (
         )
     )
 )
-then MayAccept lp ea
+then MayAccept lp ea && r34_2_b_applies lp ea &&
+     r34_6_a_defeated lp ea &&
+     r34_6_b_defeated lp ea
 
 # Example of alternative syntax for above rule.
 # RULE <r34_2_b>
@@ -377,7 +544,9 @@ if (
         )
     )
 )
-then MayAccept lp ea
+then MayAccept lp ea && r34_3_applies lp ea &&
+     r34_6_a_defeated lp ea &&
+     r34_6_b_defeated lp ea
 
 # RULE 34(4)
 # (4)  Subject to paragraph (1), a legal practitioner (not being a locum solicitor) may 
@@ -397,7 +566,9 @@ if (
         )
     )
 )
-then MayAccept lp ea
+then MayAccept lp ea && r34_4_applies lp ea &&
+     r34_6_a_defeated lp ea &&
+     r34_6_b_defeated lp ea
 
 # RULE 34(5)
 # (5)  Despite paragraph (1)(b), but subject to paragraph (1)(a) and (c) to (f), 
@@ -421,7 +592,10 @@ if (
         ) 
     )
 )
-then MayAccept lp ea
+then MayAccept lp ea && r34_5_applies lp ea &&
+     r34_6_a_defeated lp ea &&
+     r34_6_b_defeated lp ea &&
+     r34_1A_defeated lp ea
 
 # RULE 34(6)
 # (6)  Except as provided in paragraphs (2) to (5) —
@@ -440,7 +614,7 @@ if (
         )
     )
 )
-then MustNotAccept lp ea
+then MustNotAccept lp ea && r34_6_a_applies lp ea
 
 # (b)	a legal practitioner must not accept any executive appointment in a business entity.
 
@@ -451,7 +625,9 @@ if (
         Position be ea
     )
 )
-then MustNotAccept lp ea
+then MustNotAccept lp ea &&
+     r34_6_b_applies lp ea
+
 
 # RULE 34(7)
 # (7)  To avoid doubt, nothing in this rule prohibits a legal practitioner 

--- a/l4/r34.l4
+++ b/l4/r34.l4
@@ -22,11 +22,22 @@
 # 8. I think existential quantification should be implicit if the user doesn't specify.
 # 9. It not clear whether adding -> Boolean to the end of a class attribute declaration does anything.
 # 10. It's not clear whether nesting exists statements is mandatory or optional, or what it means semantically.
-# 11. It's not clear how to test for class membership. is it a unary predicate, or a `:`
+# 11. It seems inconsistent whether I'm supposed to us a unary predicate Trade o or the `:` notation.
 # 12. Are you required to use a type declaration when defining variables for an exists or forall statement? Why?
 #     I'm worried that might force people to fiddle with their object hierarchies, or that it might require
 #     making it possible to extend from multiple classes, or adopt interfaces, or whatever.
-
+# 13. I worry that using the word "class" and "extends" will cause incorrect presumptions about the semantics
+#     of those declarations.
+# 14. I don't have any way to specify boolean propositions that don't have a type. I have to use a Global type and use
+#     the `:` notation.
+# 15. I don't have equality and inequality operators?
+# 16. Things like "Beneficial Owner" are legal terms of art that are not likely to be accurately translated across langauges.
+# 17. The lexicon very quickly gets very long. Needing to re-type all the names is tedious and error prone. The wordnet
+#     references should be integrated with the class defintions.
+# 18. The lower a level of detail you choose to model, the easier it is to write the rules, and the harder it is to write
+#     the lexicon.
+# 19. It would be useful if we could also replace the default translation that GF provides on a case-by-case basis, using
+#     something like s(CASP)'s predicate statements, if generating a WordNet phrase is going to be complicated.
 
 
 # TODO: Fill out lexicon
@@ -35,6 +46,59 @@ Business -> "business_1_N"
 AssociatedWith -> "mkA2 associated_A with_Prep"
 ExecutiveAppointment -> "appointment_1_N"
 LegalPractitioner -> "lawyer_N"
+# DescribedInSection1 -> 
+# DetractsFromDignityOfLegalProfession
+# IncompatibleWithDignityOfLegalProfession
+# DerogatesFromDignityOfLegalProfession
+# Unfair
+# DescribedInFirstSchedule
+Prohibited -> "prohibit_V2"
+# InvolvesSharingFeesForLegalWorkByUnauthoirzedPersonsPerformedByTheLegalPractitioner
+# InvolvesPaymentOfCommissionsForLegalWorkByUnauthorizedPersonsPerformedByTheLegalPractioner
+Trade -> "trade_2_N"
+Calling -> "calling_N"
+# MateriallyInterferesWithAvailability
+# MateriallyInterferesWithPracticingAsLawyer
+# MateriallyInterferesWithRepresentation
+Organization -> "organization_1_N"
+Position -> "position_6_N"
+Provides -> "provide_1_V2"
+Institution -> "institution_1_N"
+# ListedInThirdSchedule
+Service -> "service_1_N"
+Legal -> "legal_4_A"
+# HeldAsRepresentativeOf
+# EntitlesHolder
+# NonExecutiveDirector
+# IndependentDirector
+# MustNotAccept
+# MayAccept
+# PrimaryOccupationIsPracticingAsLawyer
+# LocumSolicitor -> "mkN locum_N solicitorMasc_2_N"
+Person -> "person_1_N"
+# AuthorizedToPracticeLaw
+# LawPractice -> "legal_4_A practice_3_V2"
+Owner -> "owner_1_N"
+# LegalOwner
+# BeneficialOwner
+Partner -> "partner_3_N"
+SoleProprietor -> "proprietor_N"
+Director -> "director_2_N"
+# JurisdictionIsSingapore
+Member -> "member_1_N"
+# BusinessEntity 
+# ThePracticeOfLaw
+# Global
+Company -> "company_1_N"
+Corporation -> "corporation_1_N"
+Partnership -> "partnership_3_N"
+# LLP -> 
+SoleProp -> "proprietorship_N"
+# BusinessTrust -> 
+# JointLawVenture
+# FormalLawAlliance
+# ForeignLawPractice
+# ConditionsOfSecondScheduleAreSatisfied
 
 # Class definitions
 class Business {
@@ -49,6 +113,10 @@ class Business {
     InvolvesPaymentOfCommissionsForLegalWorkByUnauthorizedPersonsPerformedByTheLegalPractioner: Boolean
 }
 
+class Trade
+
+class Calling
+
 class ExecutiveAppointment extends Position {
     AssociatedWith: Business
     MateriallyInterferesWithAvailability: LegalPractitioner
@@ -58,15 +126,29 @@ class ExecutiveAppointment extends Position {
 
 class Organization {
     Position: Position
+    Provides: Service
+}
+
+class Institution extends Organization {
+    ListedInThirdSchedule: Boolean
+}
+
+class Service {
+    Legal: Boolean
 }
 
 class Position {
     HeldAsRepresentativeOf: Organization
+    EntitlesHolder: Boolean
+    NonExecutiveDirector: Boolean
+    IndependentDirector: Boolean
 }
 
 class LegalPractitioner extends Person {
     MustNotAccept: Appointment
+    MayAccept: Appointment
     PrimaryOccupationIsPracticingAsLawyer: Boolean
+    LocumSolicitor: Boolean
 }
 
 class Person {
@@ -87,6 +169,32 @@ class LawPractice extends Organization {
 }
 
 class BusinessEntity extends Organization 
+
+# This should be an atom, I think, not a predicate.
+class ThePracticeOfLaw
+
+class Global
+
+class Company
+
+class Corporation
+
+class Partnership
+
+class LLP
+
+class SoleProp
+
+class BusinessTrust
+
+class JointLawVenture
+
+class FormalLawAlliance
+
+class ForeignLawPractice
+
+
+decl ConditionsOfSecondScheduleAreSatisfied: Global
 
 # Rules
 
@@ -243,15 +351,15 @@ then MayAccept lp ea
 # RULE <r34_2_b>
 # IF
 #     LawPractice own_practice
-#         LawPractice other_practice
-#             LegalPractitioner lp
-#             ExecutiveAppointment ea
-#             JurisdictionIsSingapore own_practice
-#             JurisdictionIsSingapore other_practice
-#             not Member other_practice lp
-#             Position ea lp
-#             not ParticipationProhibited own_practice other_practice
-#             HeldAsRepresentativeOf ea own_practice
+#     LawPractice other_practice
+#     LegalPractitioner lp
+#     ExecutiveAppointment ea
+#     JurisdictionIsSingapore own_practice
+#     JurisdictionIsSingapore other_practice
+#     not Member other_practice lp
+#     Position ea lp
+#     not ParticipationProhibited own_practice other_practice
+#     HeldAsRepresentativeOf ea own_practice
 # THEN
 #     MayAccept lp ea
 
@@ -259,11 +367,38 @@ then MayAccept lp ea
 # (3)  Subject to paragraph (1), a legal practitioner may accept an executive appointment 
 # in a business entity which provides law-related services.
 
+rule <r34_3>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    exists be: BusinessEntity . (
+        Position ea be &&
+        exists s: Service . (
+            Provides be s &&
+            Legal s
+        )
+    )
+)
+then MayAccept lp ea
+
 # RULE 34(4)
 # (4)  Subject to paragraph (1), a legal practitioner (not being a locum solicitor) may 
 # accept an executive appointment in a business entity which does not provide any 
 # legal services or law-related services, if all of the conditions set out in the 
 # Second Schedule are satisfied.
+
+rule <r34_4>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    not LocumSolicitor lp &&
+    exists be: BusinessEntity. (
+        Position be ea &&
+        not exists s: Service. (
+            Provides be s &&
+            Legal s
+        )
+    )
+)
+then MayAccept lp ea
 
 # RULE 34(5)
 # (5)  Despite paragraph (1)(b), but subject to paragraph (1)(a) and (c) to (f), 
@@ -271,21 +406,76 @@ then MayAccept lp ea
 # does not provide any legal services or law-related services, if all of the 
 # conditions set out in the Second Schedule are satisfied.
 
+rule <r34_5>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    LocumSolicitor lp &&
+    Global ConditionsOfSecondScheduleAreSatisfied && 
+    exists be: BusinessEntity. (
+        Position be ea &&
+        not exists s: Service. (
+            Provides be s &&
+            (
+                Legal s ||
+                LawRelated s
+            )
+        ) 
+    )
+)
+then MayAccept lp ea
+
 # RULE 34(6)
 # (6)  Except as provided in paragraphs (2) to (5) —
 # (a)	a legal practitioner in a Singapore law practice must not accept any executive 
 # appointment in another Singapore law practice; and
 
+rule <r34_6_a>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    exists practice: LawPractice . (
+        Member practice lp &&
+        JurisdictionIsSingapore practice &&
+        exists other_practice: LawPractice . (
+            JurisdictionIsSingapore other_practice &&
+            Position other_practice ea
+        )
+    )
+)
+then MustNotAccept lp ea
+
 # (b)	a legal practitioner must not accept any executive appointment in a business entity.
+
+rule <r34_6_b>
+for lp: LegalPractitioner, ea: ExecutiveAppointment
+if (
+    exists be: BusinessEntity . (
+        Position be ea
+    )
+)
+then MustNotAccept lp ea
 
 # RULE 34(7)
 # (7)  To avoid doubt, nothing in this rule prohibits a legal practitioner 
 # from accepting any appointment in any institution set out in the Third Schedule.
 
+# assert forall lp: LegalPractitioner. (
+#     forall i: Institution. (
+#         not ListedInThirdSchedule i ||
+#         forall ea: ExecutiveAppointment. (
+#             MayAccept lp ea
+#         )
+#     )
+# )
+
 # DEFINITIONS
 # (9)  In this rule and the First to Fourth Schedules —
 # “business” includes any business, trade or calling in Singapore or elsewhere, 
 # whether or not for the purpose of profit, but excludes the practice of law;
+
+rule <def_business>
+for o: Object
+if ((Trade o || Calling o) && not ThePracticeOfLaw o)
+then Business o
 
 # “business entity”  —
 # (a)	includes any company, corporation, partnership, limited liability partnership, 
@@ -293,8 +483,53 @@ then MayAccept lp ea
 # (b)	excludes any Singapore law practice, any Joint Law Venture, any Formal Law Alliance, 
 # any foreign law practice and any institution set out in the Third Schedule;
 
+rule <def_business_entity>
+for o: Object
+if (
+    (
+        Company o ||
+        Corporation o ||
+        Partnership o ||
+        LLP o ||
+        SoleProp o ||
+        BusinessTrust o ||
+        Object o
+    ) &&
+    exists bus: Business. (
+        CarriesOn o bus
+    ) &&
+    not ( LawPractice o && JurisdictionIsSingapore o ) &&
+    not JointLawVenture o &&
+    not FormalLawAlliance o &&
+    not ForeignLawPractice o &&
+    not ( Institution o && ListedInThirdSchedule o)
+    )
+then BusinessEntity o
+
 # “executive appointment” means a position associated with a business, or in a business 
 # entity or Singapore law practice, which entitles the holder of the position to perform 
 # executive functions in relation to the business, business entity or Singapore law practice 
 # (as the case may be), but excludes any non‑executive director or independent director 
 # associated with the business or in the business entity;
+
+rule <def_executive_appointment>
+for pos: Position
+if (
+    (
+        exists practice: LawPractice. (
+            Position practice pos &&
+            not NonExecutiveDirector pos &&
+            not IndependentDirector pos
+        ) ||
+        exists business: Business. (
+            AssociatedWith pos business
+        ) ||
+        exists be: BusinessEntity. (
+            Position be pos &&
+            not NonExecutiveDirector pos &&
+            not IndependentDirector pos
+        )
+    ) &&
+    EntitlesHolder pos
+)
+then ExecutiveAppointment pos


### PR DESCRIPTION
Just adding a new version of rule 34 in the l4 example. Relates to #29. All the rules are encoded, but the defeasibility statements are not encoded, and the lexicon is only half finished.