### PR TITLE
Hash containers

### DIFF
--- a/baby-l4.cabal
+++ b/baby-l4.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.24
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -73,13 +73,13 @@ library
       MissingH
     , array
     , base >=4.7 && <5
-    , containers
     , either
     , extra
     , fgl
     , gf
     , ghc
     , graphviz
+    , hashable
     , haskeline
     , hslogger
     , hxt
@@ -100,6 +100,7 @@ library
     , tasty-hunit
     , text
     , transformers
+    , unordered-containers
   default-language: GHC2021
 
 executable hxtread
@@ -115,13 +116,13 @@ executable hxtread
     , array
     , baby-l4
     , base >=4.7 && <5
-    , containers
     , either
     , extra
     , fgl
     , gf
     , ghc
     , graphviz
+    , hashable
     , haskeline
     , hslogger
     , hxt
@@ -143,6 +144,7 @@ executable hxtread
     , tasty-hunit
     , text
     , transformers
+    , unordered-containers
   default-language: GHC2021
 
 executable l4
@@ -157,13 +159,13 @@ executable l4
     , array
     , baby-l4
     , base >=4.7 && <5
-    , containers
     , either
     , extra
     , fgl
     , gf
     , ghc
     , graphviz
+    , hashable
     , haskeline
     , hslogger
     , hxt
@@ -184,6 +186,7 @@ executable l4
     , tasty-hunit
     , text
     , transformers
+    , unordered-containers
   default-language: GHC2021
 
 test-suite tasty
@@ -232,13 +235,13 @@ test-suite tasty
       MissingH
     , array
     , base >=4.7 && <5
-    , containers
     , either
     , extra
     , fgl
     , gf
     , ghc
     , graphviz
+    , hashable
     , haskeline
     , hslogger
     , hspec ==2.*
@@ -262,4 +265,5 @@ test-suite tasty
     , tasty-hunit
     , text
     , transformers
+    , unordered-containers
   default-language: GHC2021

--- a/package.yaml
+++ b/package.yaml
@@ -20,7 +20,8 @@ description:         baby-l4 provides the core language to which natural4 compil
 dependencies:
 - base >= 4.7 && < 5
 - array
-- containers
+- hashable
+- unordered-containers
 - pretty-simple
 - prettyprinter >= 1.7.0
 - split

--- a/src/L4/Lexer.x
+++ b/src/L4/Lexer.x
@@ -1,4 +1,5 @@
 {
+{-# LANGUAGE BlockArguments #-}
 {-# OPTIONS -w  #-}
 {- HLINT ignore -}
 
@@ -27,7 +28,7 @@ import Control.Applicative as App (Applicative (..))
 import Data.Word (Word8)
 
 import Data.Char (ord)
-import qualified Data.Bits
+import Data.Bits qualified
 
 import L4.Annotation (Located(..),HasLoc(..), RealSRng(..), SRng(..), Pos(..), coordFromTo, tokenRange)
 
@@ -275,27 +276,27 @@ runAlex input__ (Alex f)
 newtype Alex a = Alex { unAlex :: AlexState -> Either Err (AlexState, a) }
 
 instance Functor Alex where
-  fmap f a = Alex $ \s -> case unAlex a s of
+  fmap f a = Alex \s -> case unAlex a s of
                             Left msg -> Left msg
                             Right (s', a') -> Right (s', f a')
 
 instance Applicative Alex where
-  pure a   = Alex $ \s -> Right (s, a)
-  fa <*> a = Alex $ \s -> case unAlex fa s of
+  pure a   = Alex \s -> Right (s, a)
+  fa <*> a = Alex \s -> case unAlex fa s of
                             Left msg -> Left msg
                             Right (s', f) -> case unAlex a s' of
                                                Left msg -> Left msg
                                                Right (s'', b) -> Right (s'', f b)
 
 instance Monad Alex where
-  m >>= k  = Alex $ \s -> case unAlex m s of
+  m >>= k  = Alex \s -> case unAlex m s of
                                 Left msg -> Left msg
                                 Right (s',a) -> unAlex (k a) s'
   return = App.pure
 
 alexGetInput :: Alex AlexInput
 alexGetInput
- = Alex $ \s@AlexState{alex_pos=pos,alex_chr=c,alex_bytes=bs,alex_inp=inp__} ->
+ = Alex \s@AlexState{alex_pos=pos,alex_chr=c,alex_bytes=bs,alex_inp=inp__} ->
         Right (s, (pos,c,bs,inp__))
 
 
@@ -305,7 +306,7 @@ alexGetInput
 alexSetInput :: AlexInput -> Alex ()
 
 alexSetInput (pos,c,bs,inp__)
- = Alex $ \s -> case s{alex_pos=pos,alex_chr=c,alex_bytes=bs,alex_inp=inp__} of
+ = Alex \s -> case s{alex_pos=pos,alex_chr=c,alex_bytes=bs,alex_inp=inp__} of
 
 
 
@@ -319,17 +320,17 @@ alexError :: Err -> Alex a
 alexError message = Alex $ const $ Left message
 
 alexGetStartCode :: Alex Int
-alexGetStartCode = Alex $ \s@AlexState{alex_scd=sc} -> Right (s, sc)
+alexGetStartCode = Alex \s@AlexState{alex_scd=sc} -> Right (s, sc)
 
 alexSetStartCode :: Int -> Alex ()
-alexSetStartCode sc = Alex $ \s -> Right (s{alex_scd=sc}, ())
+alexSetStartCode sc = Alex \s -> Right (s{alex_scd=sc}, ())
 
 
 alexGetUserState :: Alex AlexUserState
-alexGetUserState = Alex $ \s@AlexState{alex_ust=ust} -> Right (s,ust)
+alexGetUserState = Alex \s@AlexState{alex_ust=ust} -> Right (s,ust)
 
 alexSetUserState :: AlexUserState -> Alex ()
-alexSetUserState ss = Alex $ \s -> Right (s{alex_ust=ss}, ())
+alexSetUserState ss = Alex \s -> Right (s{alex_ust=ss}, ())
 
 
 alexMonadScan = do

--- a/src/L4/Syntax.hs
+++ b/src/L4/Syntax.hs
@@ -11,6 +11,8 @@ import Data.Data (Data, Typeable)
 import L4.Annotation
 import L4.KeyValueMap
 import Data.Maybe ( mapMaybe, isJust )
+import Data.Hashable
+import GHC.Generics (Generic)
 
 ----------------------------------------------------------------------
 -- Definition of expressions
@@ -25,15 +27,23 @@ type ARName = Maybe String
 --   deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 newtype ClassName = ClsNm {stringOfClassName :: String}
-  deriving (Eq, Ord, Show, Read, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable ClassName
+
 newtype FieldName = FldNm {stringOfFieldName :: String}
-  deriving (Eq, Ord, Show, Read, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable FieldName
+
 newtype PartyName = PtNm {stringOfPartyName :: String}
   deriving (Eq, Ord, Show, Read, Data, Typeable)
 
 -- a qualified var name has an annotation (contrary to a simple var name)
 data QVarName t = QVarName {annotOfQVarName :: t, nameOfQVarName :: VarName}
-  deriving (Eq, Ord, Show, Read, Functor, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Functor, Data, Typeable)
+
+instance Hashable t => Hashable (QVarName t)
 
 instance HasLoc t => HasLoc (QVarName t) where
   getLoc v = getLoc (annotOfQVarName v)
@@ -206,7 +216,9 @@ data Tp t
   | ErrT
   | OkT        -- fake type appearing in constructs (classes, rules etc.) that do not have a genuine type
   | KindT
-  deriving (Eq, Ord, Show, Read, Functor, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Functor, Data, Typeable)
+
+instance Hashable t => Hashable (Tp t)
 
 instance HasLoc t => HasLoc (Tp t) where
   getLoc e = getLoc (annotOfTp e)
@@ -250,7 +262,9 @@ pattern NumberT = ClassT () NumberC
 
 
 data VarDecl t = VarDecl {annotOfVarDecl :: t, nameOfVarDecl :: VarName, tpOfVarDecl :: Tp t}
-  deriving (Eq, Ord, Show, Read, Functor, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Functor, Data, Typeable)
+
+instance Hashable t => Hashable (VarDecl t)
 
 data VarDefn t = VarDefn {annotOfVarDefn :: t, nameOfVarDefn :: VarName, tpOfVarDefn :: Tp t, bodyOfVarDefn :: Expr t}
   deriving (Eq, Ord, Show, Read, Functor, Data, Typeable)
@@ -324,7 +338,9 @@ data Val
     -- TODO: instead of RecordV, introduce RecordE in type Expr
     -- | RecordV ClassName [(FieldName, Val)]
     | ErrV
-  deriving (Eq, Ord, Show, Read, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable Val
 
 trueV :: Expr (Tp ())
 trueV = ValE BooleanT (BoolV True)
@@ -343,52 +359,72 @@ data Var t
     -- local variable known by its provisional name and deBruijn index.
     | LocalVar { nameOfVar :: QVarName t
                , indexOfVar :: Int }
-  deriving (Eq, Ord, Show, Read, Functor, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Functor, Data, Typeable)
+
+instance Hashable t => Hashable (Var t)
 
 -- unary arithmetic operators
 data UArithOp = UAminus
-  deriving (Eq, Ord, Show, Read, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable UArithOp
 
 -- unary boolean operators
 data UBoolOp = UBnot
-  deriving (Eq, Ord, Show, Read, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable UBoolOp
 
 data UTemporalOp
   = UTAF -- always finally
   | UTAG -- always generally
   | UTEF -- exists finally
   | UTEG -- exists generally
-  deriving (Eq, Ord, Show, Read, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable UTemporalOp
 
 -- unary operators (union of the above)
 data UnaOp
     = UArith UArithOp
     | UBool UBoolOp
     | UTemporal UTemporalOp
-  deriving (Eq, Ord, Show, Read, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable UnaOp
 
 -- binary arithmetic operators
 data BArithOp = BAadd | BAsub | BAmul | BAdiv | BAmod
-  deriving (Eq, Ord, Show, Read, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable BArithOp
 
 -- binary comparison operators
 data BComparOp = BCeq | BClt | BClte | BCgt | BCgte | BCne
-  deriving (Eq, Ord, Show, Read, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable BComparOp
 
 -- binary boolean operators
 data BBoolOp = BBimpl | BBor | BBand
-  deriving (Eq, Ord, Show, Read, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable BBoolOp
 
 -- binary operators (union of the above)
 data BinOp
     = BArith BArithOp
     | BCompar BComparOp
     | BBool BBoolOp
-  deriving (Eq, Ord, Show, Read, Data, Typeable)
+  deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable BinOp
 
 -- operators for combining list elements
 data ListOp = AndList | OrList | XorList | CommaList
-    deriving (Eq, Ord, Show, Read, Data, Typeable)
+    deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable ListOp
 
 data Pattern t
     = VarP (QVarName t)
@@ -400,7 +436,9 @@ patternLength (VarP _) = 1
 patternLength (VarListP vs) = length vs
 
 data Quantif = All | Ex
-    deriving (Eq, Ord, Show, Read, Data, Typeable)
+    deriving (Eq, Generic, Ord, Show, Read, Data, Typeable)
+
+instance Hashable Quantif
 
 -- Expr t is an expression of type t (to be determined during type checking / inference)
 data Expr t
@@ -416,7 +454,9 @@ data Expr t
     | TupleE      {annotOfExpr :: t, componentsOfExprTupleE :: [Expr t]}                     -- tuples
     | CastE       {annotOfExpr :: t, tpOfExprCastE :: Tp t, subEOfExprCastE :: Expr t}               -- cast to type
     | ListE       {annotOfExpr :: t, listOpOfExprListE :: ListOp, componentsOfExprListE :: [Expr t]}    -- list expression
-    deriving (Eq, Ord, Show, Read, Functor, Data, Typeable)
+    deriving (Eq, Generic, Ord, Show, Read, Functor, Data, Typeable)
+
+instance Hashable t => Hashable (Expr t)
 
 
 childExprs :: Expr t -> [Expr t]

--- a/src/L4/SyntaxManipulation.hs
+++ b/src/L4/SyntaxManipulation.hs
@@ -9,10 +9,11 @@ module L4.SyntaxManipulation where
 --import Data.Data (Data, Typeable)
 
 import Data.Maybe (fromMaybe)
-import qualified Data.Set as Set
+import Data.HashSet qualified as Set
 --import Annotation
 --import KeyValueMap
 import L4.Syntax
+import Data.Hashable (Hashable)
 --import L4.Typing (eraseAnn, getTypeOfExpr)
 --import PrintProg (printExpr, renameAndPrintExpr)
 --import Syntax (UnaOp(UTemporal))
@@ -248,7 +249,7 @@ indexListFromTo :: Int -> Int -> [Var t] -> [Var t]
 indexListFromTo l u = indexList (reverse [l .. u])
 
 -- Free variables of an expression. Also LocalVar count as free variables.
-fv :: Ord t => Expr t -> Set.Set (Var t)
+fv :: Hashable t => Expr t -> Set.HashSet (Var t)
 fv ValE {} = Set.empty
 fv (VarE _ v) = Set.singleton v
 fv (UnaOpE _  _ e) = fv e

--- a/src/L4/TypeInference.hs
+++ b/src/L4/TypeInference.hs
@@ -22,7 +22,7 @@ import L4.SyntaxManipulation ( globalVarsOfProgram )
 
 import L4.Typing
 import Control.Monad.Writer (Functor)
-import Data.Set (member)
+import Data.HashSet (member)
 
 
 

--- a/src/RuleTransfo.hs
+++ b/src/RuleTransfo.hs
@@ -9,7 +9,7 @@ import L4.Syntax
 import L4.SyntaxManipulation (appToFunArgs, funArgsToApp, conjExpr, conjsExpr, liftType, notExpr, disjsExpr, remapExpr, eqExpr, liftExpr, isLocalVar, fv, dnf, nnf )
 import L4.Typing (distinct, eraseAnn)
 import Data.Maybe (fromMaybe)
-import Data.Set qualified as Set
+import Data.HashSet qualified as Set
 import Data.List (sortBy)
 
 import Data.Graph.Inductive.Graph
@@ -136,7 +136,7 @@ localVarExpr :: Expr t -> Bool
 localVarExpr (VarE _ (LocalVar _ _)) = True
 localVarExpr _ = False
 
-splitDecls :: Set.Set Int -> ([VarDecl t], [VarDecl t], [VarDecl t]) -> ([VarDecl t], [VarDecl t], [VarDecl t])
+splitDecls :: Set.HashSet Int -> ([VarDecl t], [VarDecl t], [VarDecl t]) -> ([VarDecl t], [VarDecl t], [VarDecl t])
 splitDecls fvs (lowers,this,[]) = (lowers,this,[])
 splitDecls fvs (lowers,this,u:us) =
   if Set.member (length lowers) fvs
@@ -353,7 +353,7 @@ data RuleProg
   | Apply String [RuleProg]
   deriving (Eq, Ord, Show, Read)
 
-ruleNamesOfRuleProg :: RuleProg -> Set.Set String
+ruleNamesOfRuleProg :: RuleProg -> Set.HashSet String
 ruleNamesOfRuleProg (RuleName rn) = Set.singleton rn
 ruleNamesOfRuleProg (Apply _ rps) = Set.unions (map ruleNamesOfRuleProg rps)
 
@@ -368,7 +368,7 @@ keyValPairToRuleProg (k,  MapVM []) = RuleName k
 keyValPairToRuleProg ("apply", MapVM ((fn,MapVM []) : args)) = Apply fn (map keyValPairToRuleProg args)
 keyValPairToRuleProg p = error ("illegal form of rule program " ++ show p)
 
-ruleNamesInDerived :: Rule t -> Set.Set String
+ruleNamesInDerived :: Rule t -> Set.HashSet String
 ruleNamesInDerived rl =
   if hasPathMap ["derived"] (instrOfRule rl)
   then ruleNamesOfRuleProg (derivedInstrToRuleProg (instrOfRule rl))

--- a/src/ToDMN/FromL4.hs
+++ b/src/ToDMN/FromL4.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module ToDMN.FromL4 where
@@ -153,7 +154,7 @@ isValidPostcond = unaryApp . postcondOfRule
 -- postcond should app of single pred to single arg
 filterRules :: Show t => [Rule t] -> [Rule t]
 -- filterRules = filter (\r -> isValidPrecond r)
-filterRules = filter (\r -> isValidPrecond r && isValidPostcond r)
+filterRules = filter \r -> isValidPrecond r && isValidPostcond r
 
 
 -- classify :: Eq a => [a] -> [[a]]

--- a/src/ToDMN/FromL4.hs
+++ b/src/ToDMN/FromL4.hs
@@ -4,7 +4,7 @@ module ToDMN.FromL4 where
 
 import Data.Function qualified as Fn
 import Data.List qualified as List
-import Data.Map qualified as Map
+import Data.HashMap.Strict qualified as Map
 import Debug.Trace qualified as Debug
 
 import Control.Monad.Trans.State (runState)

--- a/src/ToDMN/FromSimpleToReg.hs
+++ b/src/ToDMN/FromSimpleToReg.hs
@@ -3,10 +3,10 @@ module ToDMN.FromSimpleToReg where
 
 import ToDMN.Types
 import Control.Monad.Trans.State
-import Data.Map qualified as Map
+import Data.HashMap.Strict qualified as Map
 import Data.Maybe
 
-type ID = State (Map.Map String Int)
+type ID = State (Map.HashMap String Int)
 
 mkID :: String -> ID String
 mkID pfx = do

--- a/tests/ExpSysTest.hs
+++ b/tests/ExpSysTest.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BlockArguments #-}
+
 module ExpSysTest where
 
 import L4.Syntax
@@ -12,7 +14,7 @@ import Test.Tasty
 import Test.Tasty.ExpectedFailure
 import Test.Tasty.HUnit
 import Data.Either ( rights )
-import Data.Set as S
+import Data.HashSet as S
 import Data.Tuple (snd)
 import L4.SyntaxManipulation (appToFunArgs)
 
@@ -39,35 +41,35 @@ progToRule progIO rname = do
     pure $ head $ obtRule prog rname
 
 esGraphUTs :: TestTree
-esGraphUTs = withResource acquire release $ \progIO->
+esGraphUTs = withResource acquire release \progIO->
     testGroup "Expert System: Graph Generation Tests"
         [ testGroup "isRule"
-            [ testCase "returns True for <accInad>" $ do
+            [ testCase "returns True for <accInad>" do
                 rule <- progToRule progIO "accInad"
                 SR.isRule rule @?= True
-            , testCase "returns True for <accAdIncInad>" $ do
+            , testCase "returns True for <accAdIncInad>" do
                 rule <- progToRule progIO "accAdIncInad"
                 SR.isRule rule @?= True
-            , testCase "returns True for <savingsAd>" $ do
+            , testCase "returns True for <savingsAd>" do
                 rule <- progToRule progIO "savingsAd"
                 SR.isRule rule @?= True
             ]
         , testGroup "flattenConjs"
-            [ testCase "returns 1 AppE for preconds of <accInad>" $ do
+            [ testCase "returns 1 AppE for preconds of <accInad>" do
                 rule <- progToRule progIO "accInad"
                 length (SR.flattenConjs . precondOfRule $ rule) @?= 1
-            , testCase "returns 2 AppE for preconds of <accAdIncInad>" $ do
+            , testCase "returns 2 AppE for preconds of <accAdIncInad>" do
                 rule <- progToRule progIO "accAdIncInad"
                 length (SR.flattenConjs . precondOfRule $ rule) @?= 2
-            , testCase "returns 2 AppE for preconds of <savingsAd>" $ do
+            , testCase "returns 2 AppE for preconds of <savingsAd>" do
                 rule <- progToRule progIO "savingsAd"
                 length (SR.flattenConjs . precondOfRule $ rule) @?= 2
             ]
-        , testCase "print the set of nodes and edges for a single rule" $ do
+        , testCase "print the set of nodes and edges for a single rule" do
                 rule <- progToRule progIO "accInad"
                 print $ SR.simpleRulesToGrNodes $ rights [SR.ruleToSimpleRule rule]
                 'a' @?= 'a'
-        , testCase "mapping a single rule twice = convert a list of simple rules" $ do
+        , testCase "mapping a single rule twice = convert a list of simple rules" do
             rule1 <- progToRule progIO "accInad"
             rule2 <- progToRule progIO "savingsAd"
             let (nodes1, edges1) = SR.simpleRuleToGrNodes $ head . rights $ [SR.ruleToSimpleRule rule1]
@@ -79,7 +81,7 @@ esGraphUTs = withResource acquire release $ \progIO->
 
 
 esRuleUTs :: TestTree
-esRuleUTs = withResource acquire release $ \progIO->
+esRuleUTs = withResource acquire release \progIO->
     testGroup "Expert System: Rule Translation Tests" [ ]
     where acquire = getProg "tests/ExpSysTestFiles/finAd_tests.l4"
           release = mempty


### PR DESCRIPTION
- Switch from ordered `Map` to `HashMap` and  `Set` to `HashSet`, because all the keys being compared were either strings or more complex data structures containing strings.
  - Note that in such cases, O(log2(n)) comparisons each worth O(|k|) is significantly more inefficient than comparing hashes.
- Introduce a minimal set of rules to derive `Hashable` constraints for all types which are transitive dependencies of `Expr t`.
- Use the `BlockArguments` language extension in some places to save on a few parens and `$`.