### PR TITLE
Use Double instead of Float

### DIFF
--- a/src/L4/Lexer.x
+++ b/src/L4/Lexer.x
@@ -482,7 +482,7 @@ data TokenKind
   | TokenStringLit String
 
   | TokenInteger Integer
-  | TokenFloat Float
+  | TokenFloat Double
   | TokenSym String
   | TokenString String
   deriving (Eq,Show)

--- a/src/L4/Syntax.hs
+++ b/src/L4/Syntax.hs
@@ -327,7 +327,7 @@ instance HasAnnot ClassDecl where
 data Val
     = BoolV Bool
     | IntV Integer
-    | FloatV Float
+    | FloatV Double
     | StringV String
     -- TODO: instead of RecordV, introduce RecordE in type Expr
     -- | RecordV ClassName [(FieldName, Val)]

--- a/src/L4/SyntaxManipulation.hs
+++ b/src/L4/SyntaxManipulation.hs
@@ -54,7 +54,7 @@ globalVarsOfProgram prg = varDeclsOfProgram prg ++ map varDefnToVarDecl (varDefn
 mkIntConst :: Integer -> Expr (Tp())
 mkIntConst f = ValE IntegerT (IntV f)
 
-mkFloatConst :: Float -> Expr (Tp())
+mkFloatConst :: Double -> Expr (Tp())
 mkFloatConst f = ValE FloatT (FloatV f)
 
 mkVarE :: Var t -> Expr t


### PR DESCRIPTION
Upgrade babyl4 to use 64 bit double precision floating numbers instead of 32 bit single precision.